### PR TITLE
Skip impossible tests, nose compatibility, test setup

### DIFF
--- a/ecdsa/test_pyecdsa.py
+++ b/ecdsa/test_pyecdsa.py
@@ -20,6 +20,17 @@ from .ellipticcurve import Point
 from . import der
 from . import rfc6979
 
+# provide missing unittest decorators and API for python 2.6; these decorators
+# do not actually work, just avoid the syntax failure
+if sys.version_info[:2] == (2, 6):
+    def skipUnless(condition, reason):
+        if not condition:
+            sys.stderr.write('[expected failure] ')
+        return lambda obj: obj
+
+    unittest.skipUnless = skipUnless
+    unittest.expectedFailure = lambda obj: obj
+
 class SubprocessError(Exception):
     pass
 

--- a/ecdsa/test_pyecdsa.py
+++ b/ecdsa/test_pyecdsa.py
@@ -5,6 +5,7 @@ import os
 import time
 import shutil
 import subprocess
+import sys
 from binascii import hexlify, unhexlify
 from hashlib import sha1, sha256, sha512
 


### PR DESCRIPTION
Some OpenSSL builds can only use some of the ECs, so we should skip testing ecdsa if OpenSSL doesn't support the EC.
Also, nose seems to detect do_test as a test to be run, so remove _test from the helper functions in the OpenSSL test clases.
There is also no need to run openssl version multiple times, so cache the result of the helper function.

fixes #46