### PR TITLE
Fix parameter call of openssl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ into other protocols.
 This library provides key generation, signing, and verifying, for five
 popular NIST "Suite B" GF(p) curves, with key lengths of 192, 224, 256, 384,
 and 521 bits. The "short names" for these curves, as known by the OpenSSL
-tool (`openssl ecparam --list_curves`), are: prime192v1, secp224r1,
+tool (`openssl ecparam -list_curves`), are: prime192v1, secp224r1,
 prime256v1, secp384r1, and secp521r1. It also includes the 256-bit curve used
 by Bitcoin, whose short name is secp256k1. No other curves are included, but
 it would not be too hard to add more.


### PR DESCRIPTION
The parameters with openssl are using only one dash.