### PR TITLE
Make Python 3.5 support official

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
 install: true
 script:

--- a/setup.py
+++ b/setup.py
@@ -93,5 +93,6 @@ setup(name="ecdsa",
           "Programming Language :: Python :: 3.2",
           "Programming Language :: Python :: 3.3",
           "Programming Language :: Python :: 3.4",
+          "Programming Language :: Python :: 3.5",
       ],
 )


### PR DESCRIPTION
Since the test suite works on Python 3.5 without any problems, make the support official. Also make sure that it stays like this by including it in Travis setup