### PR TITLE
PEP8 compliance, whitespace only

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The following table shows how long this library takes to generate keypairs
 (keygen=), to sign data (sign=), and to verify those signatures (verify=), on
 my 2008 Mac laptop. All times are in seconds. It also shows the length of a
 signature (in bytes): the verifying ("public") key is typically the same
-length as the signature, and the signing ("private") key is half that length. Use "python setup.py speed" to generate this table on your own computer.
+length as the signature, and the signing ("private") key is half that length.
+Use "python setup.py speed" to generate this table on your own computer.
 
 * NIST192p: siglen= 48, keygen=0.160s, sign=0.058s, verify=0.116s
 * NIST224p: siglen= 56, keygen=0.230s, sign=0.086s, verify=0.165s

--- a/ecdsa/__init__.py
+++ b/ecdsa/__init__.py
@@ -1,14 +1,14 @@
-__all__ = ["curves", "der", "ecdsa", "ellipticcurve", "keys", "numbertheory",
-           "test_pyecdsa", "util", "six"]
 from .keys import SigningKey, VerifyingKey, BadSignatureError, BadDigestError
 from .curves import NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, SECP256k1
+
+# This code comes from http://github.com/warner/python-ecdsa
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions
+
+__all__ = ["curves", "der", "ecdsa", "ellipticcurve", "keys", "numbertheory",
+           "test_pyecdsa", "util", "six"]
 
 _hush_pyflakes = [SigningKey, VerifyingKey, BadSignatureError, BadDigestError,
                   NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, SECP256k1]
 del _hush_pyflakes
-
-# This code comes from http://github.com/warner/python-ecdsa
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions

--- a/ecdsa/curves.py
+++ b/ecdsa/curves.py
@@ -2,17 +2,20 @@ from __future__ import division
 
 from . import der, ecdsa
 
+
 class UnknownCurveError(Exception):
     pass
 
+
 def orderlen(order):
-    return (1+len("%x"%order))//2 # bytes
+    return (1+len("%x" % order))//2  # bytes
+
 
 # the NIST curves
 class Curve:
     def __init__(self, name, curve, generator, oid, openssl_name=None):
         self.name = name
-        self.openssl_name = openssl_name # maybe None
+        self.openssl_name = openssl_name  # maybe None
         self.curve = curve
         self.generator = generator
         self.order = generator.order()
@@ -22,20 +25,27 @@ class Curve:
         self.oid = oid
         self.encoded_oid = der.encode_oid(*oid)
 
-NIST192p = Curve("NIST192p", ecdsa.curve_192, ecdsa.generator_192,
+NIST192p = Curve("NIST192p", ecdsa.curve_192,
+                 ecdsa.generator_192,
                  (1, 2, 840, 10045, 3, 1, 1), "prime192v1")
-NIST224p = Curve("NIST224p", ecdsa.curve_224, ecdsa.generator_224,
+NIST224p = Curve("NIST224p", ecdsa.curve_224,
+                 ecdsa.generator_224,
                  (1, 3, 132, 0, 33), "secp224r1")
-NIST256p = Curve("NIST256p", ecdsa.curve_256, ecdsa.generator_256,
+NIST256p = Curve("NIST256p", ecdsa.curve_256,
+                 ecdsa.generator_256,
                  (1, 2, 840, 10045, 3, 1, 7), "prime256v1")
-NIST384p = Curve("NIST384p", ecdsa.curve_384, ecdsa.generator_384,
+NIST384p = Curve("NIST384p", ecdsa.curve_384,
+                 ecdsa.generator_384,
                  (1, 3, 132, 0, 34), "secp384r1")
-NIST521p = Curve("NIST521p", ecdsa.curve_521, ecdsa.generator_521,
+NIST521p = Curve("NIST521p", ecdsa.curve_521,
+                 ecdsa.generator_521,
                  (1, 3, 132, 0, 35), "secp521r1")
-SECP256k1 = Curve("SECP256k1", ecdsa.curve_secp256k1, ecdsa.generator_secp256k1,
+SECP256k1 = Curve("SECP256k1", ecdsa.curve_secp256k1,
+                  ecdsa.generator_secp256k1,
                   (1, 3, 132, 0, 10), "secp256k1")
 
 curves = [NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, SECP256k1]
+
 
 def find_curve(oid_curve):
     for c in curves:

--- a/ecdsa/ecdsa.py
+++ b/ecdsa/ecdsa.py
@@ -59,21 +59,19 @@ from . import numbertheory
 import random
 
 
-
-class Signature( object ):
+class Signature(object):
   """ECDSA signature.
   """
-  def __init__( self, r, s ):
+  def __init__(self, r, s):
     self.r = r
     self.s = s
 
 
-
-class Public_key( object ):
+class Public_key(object):
   """Public key for ECDSA.
   """
 
-  def __init__( self, generator, point ):
+  def __init__(self, generator, point):
     """generator is the Point that generates the group,
     point is the Point that defines the public key.
     """
@@ -89,8 +87,7 @@ class Public_key( object ):
     if point.x() < 0 or n <= point.x() or point.y() < 0 or n <= point.y():
       raise RuntimeError("Generator point has x or y out of range.")
 
-
-  def verifies( self, hash, signature ):
+  def verifies(self, hash, signature):
     """Verify that signature is a valid signature of hash.
     Return True if the signature is valid.
     """
@@ -101,22 +98,23 @@ class Public_key( object ):
     n = G.order()
     r = signature.r
     s = signature.s
-    if r < 1 or r > n-1: return False
-    if s < 1 or s > n-1: return False
-    c = numbertheory.inverse_mod( s, n )
-    u1 = ( hash * c ) % n
-    u2 = ( r * c ) % n
+    if r < 1 or r > n - 1:
+      return False
+    if s < 1 or s > n - 1:
+      return False
+    c = numbertheory.inverse_mod(s, n)
+    u1 = (hash * c) % n
+    u2 = (r * c) % n
     xy = u1 * G + u2 * self.point
     v = xy.x() % n
     return v == r
 
 
-
-class Private_key( object ):
+class Private_key(object):
   """Private key for ECDSA.
   """
 
-  def __init__( self, public_key, secret_multiplier ):
+  def __init__(self, public_key, secret_multiplier):
     """public_key is of class Public_key;
     secret_multiplier is a large integer.
     """
@@ -124,7 +122,7 @@ class Private_key( object ):
     self.public_key = public_key
     self.secret_multiplier = secret_multiplier
 
-  def sign( self, hash, random_k ):
+  def sign(self, hash, random_k):
     """Return a signature for the provided hash, using the provided
     random nonce.  It is absolutely vital that random_k be an unpredictable
     number in the range [1, self.public_key.point.order()-1].  If
@@ -144,18 +142,20 @@ class Private_key( object ):
     k = random_k % n
     p1 = k * G
     r = p1.x()
-    if r == 0: raise RuntimeError("amazingly unlucky random number r")
-    s = ( numbertheory.inverse_mod( k, n ) * \
-          ( hash + ( self.secret_multiplier * r ) % n ) ) % n
-    if s == 0: raise RuntimeError("amazingly unlucky random number s")
-    return Signature( r, s )
+    if r == 0:
+      raise RuntimeError("amazingly unlucky random number r")
+    s = (numbertheory.inverse_mod(k, n) *
+         (hash + (self.secret_multiplier * r) % n)) % n
+    if s == 0:
+      raise RuntimeError("amazingly unlucky random number s")
+    return Signature(r, s)
 
 
-
-def int_to_string( x ):
+def int_to_string(x):
   """Convert integer x into a string of bytes, as per X9.62."""
   assert x >= 0
-  if x == 0: return b('\0')
+  if x == 0:
+    return b('\0')
   result = []
   while x:
     ordinal = x & 0xFF
@@ -166,16 +166,17 @@ def int_to_string( x ):
   return b('').join(result)
 
 
-def string_to_int( s ):
+def string_to_int(s):
   """Convert a string of bytes into an integer, as per X9.62."""
   result = 0
   for c in s:
-    if not isinstance(c, int): c = ord( c )
+    if not isinstance(c, int):
+      c = ord(c)
     result = 256 * result + c
   return result
 
 
-def digest_integer( m ):
+def digest_integer(m):
   """Convert an integer into a string of bytes, compute
      its SHA-1 hash, and convert the result to an integer."""
   #
@@ -184,10 +185,10 @@ def digest_integer( m ):
   # in ECDSAVS.
   #
   from hashlib import sha1
-  return string_to_int( sha1( int_to_string( m ) ).digest() )
+  return string_to_int(sha1(int_to_string(m)).digest())
 
 
-def point_is_valid( generator, x, y ):
+def point_is_valid(generator, x, y):
   """Is (x,y) a valid public key based on the specified generator?"""
 
   # These are the tests specified in X9.62.
@@ -196,13 +197,11 @@ def point_is_valid( generator, x, y ):
   curve = generator.curve()
   if x < 0 or n <= x or y < 0 or n <= y:
     return False
-  if not curve.contains_point( x, y ):
+  if not curve.contains_point(x, y):
     return False
-  if not n*ellipticcurve.Point( curve, x, y ) == \
-     ellipticcurve.INFINITY:
+  if not n * ellipticcurve.Point(curve, x, y) == ellipticcurve.INFINITY:
     return False
   return True
-
 
 
 # NIST Curve P-192:
@@ -214,8 +213,8 @@ _b = 0x64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1
 _Gx = 0x188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012
 _Gy = 0x07192b95ffc8da78631011ed6b24cdd573f977a11e794811
 
-curve_192 = ellipticcurve.CurveFp( _p, -3, _b )
-generator_192 = ellipticcurve.Point( curve_192, _Gx, _Gy, _r )
+curve_192 = ellipticcurve.CurveFp(_p, -3, _b)
+generator_192 = ellipticcurve.Point(curve_192, _Gx, _Gy, _r)
 
 
 # NIST Curve P-224:
@@ -224,11 +223,11 @@ _r = 26959946667150639794667015087019625940457807714424391721682722368061
 # s = 0xbd71344799d5c7fcdc45b59fa3b9ab8f6a948bc5L
 # c = 0x5b056c7e11dd68f40469ee7f3c7a7d74f7d121116506d031218291fbL
 _b = 0xb4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4
-_Gx =0xb70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21
+_Gx = 0xb70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21
 _Gy = 0xbd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34
 
-curve_224 = ellipticcurve.CurveFp( _p, -3, _b )
-generator_224 = ellipticcurve.Point( curve_224, _Gx, _Gy, _r )
+curve_224 = ellipticcurve.CurveFp(_p, -3, _b)
+generator_224 = ellipticcurve.Point(curve_224, _Gx, _Gy, _r)
 
 # NIST Curve P-256:
 _p = 115792089210356248762697446949407573530086143415290314195533631308867097853951
@@ -239,8 +238,8 @@ _b = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b
 _Gx = 0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296
 _Gy = 0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5
 
-curve_256 = ellipticcurve.CurveFp( _p, -3, _b )
-generator_256 = ellipticcurve.Point( curve_256, _Gx, _Gy, _r )
+curve_256 = ellipticcurve.CurveFp(_p, -3, _b)
+generator_256 = ellipticcurve.Point(curve_256, _Gx, _Gy, _r)
 
 # NIST Curve P-384:
 _p = 39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319
@@ -251,8 +250,8 @@ _b = 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8
 _Gx = 0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7
 _Gy = 0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f
 
-curve_384 = ellipticcurve.CurveFp( _p, -3, _b )
-generator_384 = ellipticcurve.Point( curve_384, _Gx, _Gy, _r )
+curve_384 = ellipticcurve.CurveFp(_p, -3, _b)
+generator_384 = ellipticcurve.Point(curve_384, _Gx, _Gy, _r)
 
 # NIST Curve P-521:
 _p = 6864797660130609714981900799081393217269435300143305409394463459185543183397656052122559640661454554977296311391480858037121987999716643812574028291115057151
@@ -263,46 +262,46 @@ _b = 0x051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e1561939
 _Gx = 0xc6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66
 _Gy = 0x11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650
 
-curve_521 = ellipticcurve.CurveFp( _p, -3, _b )
-generator_521 = ellipticcurve.Point( curve_521, _Gx, _Gy, _r )
+curve_521 = ellipticcurve.CurveFp(_p, -3, _b)
+generator_521 = ellipticcurve.Point(curve_521, _Gx, _Gy, _r)
 
 # Certicom secp256-k1
-_a  = 0x0000000000000000000000000000000000000000000000000000000000000000
-_b  = 0x0000000000000000000000000000000000000000000000000000000000000007
-_p  = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
+_a = 0x0000000000000000000000000000000000000000000000000000000000000000
+_b = 0x0000000000000000000000000000000000000000000000000000000000000007
+_p = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
 _Gx = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
 _Gy = 0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8
-_r  = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+_r = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
 
-curve_secp256k1 = ellipticcurve.CurveFp( _p, _a, _b)
-generator_secp256k1 = ellipticcurve.Point( curve_secp256k1, _Gx, _Gy, _r)
-
+curve_secp256k1 = ellipticcurve.CurveFp(_p, _a, _b)
+generator_secp256k1 = ellipticcurve.Point(curve_secp256k1, _Gx, _Gy, _r)
 
 
 def __main__():
-  class TestFailure(Exception): pass
+  class TestFailure(Exception):
+    pass
 
-  def test_point_validity( generator, x, y, expected ):
+  def test_point_validity(generator, x, y, expected):
     """generator defines the curve; is (x,y) a point on
        this curve? "expected" is True if the right answer is Yes."""
-    if point_is_valid( generator, x, y ) == expected:
+    if point_is_valid(generator, x, y) == expected:
       print_("Point validity tested as expected.")
     else:
       raise TestFailure("*** Point validity test gave wrong result.")
 
-  def test_signature_validity( Msg, Qx, Qy, R, S, expected ):
+  def test_signature_validity(Msg, Qx, Qy, R, S, expected):
     """Msg = message, Qx and Qy represent the base point on
        elliptic curve c192, R and S are the signature, and
        "expected" is True iff the signature is expected to be valid."""
-    pubk = Public_key( generator_192,
-                       ellipticcurve.Point( curve_192, Qx, Qy ) )
-    got = pubk.verifies( digest_integer( Msg ), Signature( R, S ) )
+    pubk = Public_key(generator_192,
+                      ellipticcurve.Point(curve_192, Qx, Qy))
+    got = pubk.verifies(digest_integer(Msg), Signature(R, S))
     if got == expected:
       print_("Signature tested as expected: got %s, expected %s." % \
-            ( got, expected ))
+             (got, expected))
     else:
       raise TestFailure("*** Signature test failed: got %s, expected %s." % \
-                        ( got, expected ))
+                        (got, expected))
 
   print_("NIST Curve P-192:")
 
@@ -335,9 +334,9 @@ def __main__():
     print_("u1 * p192 + u2 * Q came out right.")
 
   e = 968236873715988614170569073515315707566766479517
-  pubk = Public_key( generator_192, generator_192 * d )
-  privk = Private_key( pubk, d )
-  sig = privk.sign( e, k )
+  pubk = Public_key(generator_192, generator_192 * d)
+  privk = Private_key(pubk, d)
+  sig = privk.sign(e, k)
   r, s = sig.r, sig.s
   if r != 3342403536405981729393488334694600415596881826869351677613 \
      or s != 5735822328888155254683894997897571951568553642892029982342:
@@ -345,13 +344,17 @@ def __main__():
   else:
     print_("r and s came out right.")
 
-  valid = pubk.verifies( e, sig )
-  if valid: print_("Signature verified OK.")
-  else: raise TestFailure("*** Signature failed verification.")
+  valid = pubk.verifies(e, sig)
+  if valid:
+    print_("Signature verified OK.")
+  else:
+    raise TestFailure("*** Signature failed verification.")
 
-  valid = pubk.verifies( e-1, sig )
-  if not valid: print_("Forgery was correctly rejected.")
-  else: raise TestFailure("*** Forgery was erroneously accepted.")
+  valid = pubk.verifies(e - 1, sig)
+  if not valid:
+    print_("Forgery was correctly rejected.")
+  else:
+    raise TestFailure("*** Forgery was erroneously accepted.")
 
   print_("Testing point validity, as per ECDSAVS.pdf B.2.2:")
 
@@ -359,73 +362,73 @@ def __main__():
     p192, \
     0xcd6d0f029a023e9aaca429615b8f577abee685d8257cc83a, \
     0x00019c410987680e9fb6c0b6ecc01d9a2647c8bae27721bacdfc, \
-    False )
+    False)
 
   test_point_validity(
     p192, \
     0x00017f2fce203639e9eaf9fb50b81fc32776b30e3b02af16c73b, \
     0x95da95c5e72dd48e229d4748d4eee658a9a54111b23b2adb, \
-    False )
+    False)
 
   test_point_validity(
     p192, \
     0x4f77f8bc7fccbadd5760f4938746d5f253ee2168c1cf2792, \
     0x000147156ff824d131629739817edb197717c41aab5c2a70f0f6, \
-    False )
+    False)
 
   test_point_validity(
     p192, \
     0xc58d61f88d905293bcd4cd0080bcb1b7f811f2ffa41979f6, \
     0x8804dc7a7c4c7f8b5d437f5156f3312ca7d6de8a0e11867f, \
-    True )
+    True)
 
   test_point_validity(
     p192, \
     0xcdf56c1aa3d8afc53c521adf3ffb96734a6a630a4a5b5a70, \
     0x97c1c44a5fb229007b5ec5d25f7413d170068ffd023caa4e, \
-    True )
+    True)
 
   test_point_validity(
     p192, \
     0x89009c0dc361c81e99280c8e91df578df88cdf4b0cdedced, \
     0x27be44a529b7513e727251f128b34262a0fd4d8ec82377b9, \
-    True )
+    True)
 
   test_point_validity(
     p192, \
     0x6a223d00bd22c52833409a163e057e5b5da1def2a197dd15, \
     0x7b482604199367f1f303f9ef627f922f97023e90eae08abf, \
-    True )
+    True)
 
   test_point_validity(
     p192, \
     0x6dccbde75c0948c98dab32ea0bc59fe125cf0fb1a3798eda, \
     0x0001171a3e0fa60cf3096f4e116b556198de430e1fbd330c8835, \
-    False )
+    False)
 
   test_point_validity(
     p192, \
     0xd266b39e1f491fc4acbbbc7d098430931cfa66d55015af12, \
     0x193782eb909e391a3148b7764e6b234aa94e48d30a16dbb2, \
-    False )
+    False)
 
   test_point_validity(
     p192, \
     0x9d6ddbcd439baa0c6b80a654091680e462a7d1d3f1ffeb43, \
     0x6ad8efc4d133ccf167c44eb4691c80abffb9f82b932b8caa, \
-    False )
+    False)
 
   test_point_validity(
     p192, \
     0x146479d944e6bda87e5b35818aa666a4c998a71f4e95edbc, \
     0xa86d6fe62bc8fbd88139693f842635f687f132255858e7f6, \
-    False )
+    False)
 
   test_point_validity(
     p192, \
     0xe594d4a598046f3598243f50fd2c7bd7d380edb055802253, \
     0x509014c0c4d6b536e3ca750ec09066af39b4c8616a53a923, \
-    False )
+    False)
 
   print_("Trying signature-verification tests from ECDSAVS.pdf B.2.4:")
   print_("P-192:")
@@ -434,107 +437,105 @@ def __main__():
   Qy = 0x282102e364feded3ad15ddf968f88d8321aa268dd483ebc4
   R = 0x64dca58a20787c488d11d6dd96313f1b766f2d8efe122916
   S = 0x1ecba28141e84ab4ecad92f56720e2cc83eb3d22dec72479
-  test_signature_validity( Msg, Qx, Qy, R, S, True )
+  test_signature_validity(Msg, Qx, Qy, R, S, True)
 
   Msg = 0x94bb5bacd5f8ea765810024db87f4224ad71362a3c28284b2b9f39fab86db12e8beb94aae899768229be8fdb6c4f12f28912bb604703a79ccff769c1607f5a91450f30ba0460d359d9126cbd6296be6d9c4bb96c0ee74cbb44197c207f6db326ab6f5a659113a9034e54be7b041ced9dcf6458d7fb9cbfb2744d999f7dfd63f4
   Qx = 0x3e53ef8d3112af3285c0e74842090712cd324832d4277ae7
   Qy = 0xcc75f8952d30aec2cbb719fc6aa9934590b5d0ff5a83adb7
   R = 0x8285261607283ba18f335026130bab31840dcfd9c3e555af
   S = 0x356d89e1b04541afc9704a45e9c535ce4a50929e33d7e06c
-  test_signature_validity( Msg, Qx, Qy, R, S, True )
+  test_signature_validity(Msg, Qx, Qy, R, S, True)
 
   Msg = 0xf6227a8eeb34afed1621dcc89a91d72ea212cb2f476839d9b4243c66877911b37b4ad6f4448792a7bbba76c63bdd63414b6facab7dc71c3396a73bd7ee14cdd41a659c61c99b779cecf07bc51ab391aa3252386242b9853ea7da67fd768d303f1b9b513d401565b6f1eb722dfdb96b519fe4f9bd5de67ae131e64b40e78c42dd
   Qx = 0x16335dbe95f8e8254a4e04575d736befb258b8657f773cb7
   Qy = 0x421b13379c59bc9dce38a1099ca79bbd06d647c7f6242336
   R = 0x4141bd5d64ea36c5b0bd21ef28c02da216ed9d04522b1e91
   S = 0x159a6aa852bcc579e821b7bb0994c0861fb08280c38daa09
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x16b5f93afd0d02246f662761ed8e0dd9504681ed02a253006eb36736b563097ba39f81c8e1bce7a16c1339e345efabbc6baa3efb0612948ae51103382a8ee8bc448e3ef71e9f6f7a9676694831d7f5dd0db5446f179bcb737d4a526367a447bfe2c857521c7f40b6d7d7e01a180d92431fb0bbd29c04a0c420a57b3ed26ccd8a
   Qx = 0xfd14cdf1607f5efb7b1793037b15bdf4baa6f7c16341ab0b
   Qy = 0x83fa0795cc6c4795b9016dac928fd6bac32f3229a96312c4
   R = 0x8dfdb832951e0167c5d762a473c0416c5c15bc1195667dc1
   S = 0x1720288a2dc13fa1ec78f763f8fe2ff7354a7e6fdde44520
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x08a2024b61b79d260e3bb43ef15659aec89e5b560199bc82cf7c65c77d39192e03b9a895d766655105edd9188242b91fbde4167f7862d4ddd61e5d4ab55196683d4f13ceb90d87aea6e07eb50a874e33086c4a7cb0273a8e1c4408f4b846bceae1ebaac1b2b2ea851a9b09de322efe34cebe601653efd6ddc876ce8c2f2072fb
   Qx = 0x674f941dc1a1f8b763c9334d726172d527b90ca324db8828
   Qy = 0x65adfa32e8b236cb33a3e84cf59bfb9417ae7e8ede57a7ff
   R = 0x9508b9fdd7daf0d8126f9e2bc5a35e4c6d800b5b804d7796
   S = 0x36f2bf6b21b987c77b53bb801b3435a577e3d493744bfab0
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x1843aba74b0789d4ac6b0b8923848023a644a7b70afa23b1191829bbe4397ce15b629bf21a8838298653ed0c19222b95fa4f7390d1b4c844d96e645537e0aae98afb5c0ac3bd0e4c37f8daaff25556c64e98c319c52687c904c4de7240a1cc55cd9756b7edaef184e6e23b385726e9ffcba8001b8f574987c1a3fedaaa83ca6d
   Qx = 0x10ecca1aad7220b56a62008b35170bfd5e35885c4014a19f
   Qy = 0x04eb61984c6c12ade3bc47f3c629ece7aa0a033b9948d686
   R = 0x82bfa4e82c0dfe9274169b86694e76ce993fd83b5c60f325
   S = 0xa97685676c59a65dbde002fe9d613431fb183e8006d05633
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x5a478f4084ddd1a7fea038aa9732a822106385797d02311aeef4d0264f824f698df7a48cfb6b578cf3da416bc0799425bb491be5b5ecc37995b85b03420a98f2c4dc5c31a69a379e9e322fbe706bbcaf0f77175e05cbb4fa162e0da82010a278461e3e974d137bc746d1880d6eb02aa95216014b37480d84b87f717bb13f76e1
   Qx = 0x6636653cb5b894ca65c448277b29da3ad101c4c2300f7c04
   Qy = 0xfdf1cbb3fc3fd6a4f890b59e554544175fa77dbdbeb656c1
   R = 0xeac2ddecddfb79931a9c3d49c08de0645c783a24cb365e1c
   S = 0x3549fee3cfa7e5f93bc47d92d8ba100e881a2a93c22f8d50
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0xc598774259a058fa65212ac57eaa4f52240e629ef4c310722088292d1d4af6c39b49ce06ba77e4247b20637174d0bd67c9723feb57b5ead232b47ea452d5d7a089f17c00b8b6767e434a5e16c231ba0efa718a340bf41d67ea2d295812ff1b9277daacb8bc27b50ea5e6443bcf95ef4e9f5468fe78485236313d53d1c68f6ba2
   Qx = 0xa82bd718d01d354001148cd5f69b9ebf38ff6f21898f8aaa
   Qy = 0xe67ceede07fc2ebfafd62462a51e4b6c6b3d5b537b7caf3e
   R = 0x4d292486c620c3de20856e57d3bb72fcde4a73ad26376955
   S = 0xa85289591a6081d5728825520e62ff1c64f94235c04c7f95
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0xca98ed9db081a07b7557f24ced6c7b9891269a95d2026747add9e9eb80638a961cf9c71a1b9f2c29744180bd4c3d3db60f2243c5c0b7cc8a8d40a3f9a7fc910250f2187136ee6413ffc67f1a25e1c4c204fa9635312252ac0e0481d89b6d53808f0c496ba87631803f6c572c1f61fa049737fdacce4adff757afed4f05beb658
   Qx = 0x7d3b016b57758b160c4fca73d48df07ae3b6b30225126c2f
   Qy = 0x4af3790d9775742bde46f8da876711be1b65244b2b39e7ec
   R = 0x95f778f5f656511a5ab49a5d69ddd0929563c29cbc3a9e62
   S = 0x75c87fc358c251b4c83d2dd979faad496b539f9f2ee7a289
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x31dd9a54c8338bea06b87eca813d555ad1850fac9742ef0bbe40dad400e10288acc9c11ea7dac79eb16378ebea9490e09536099f1b993e2653cd50240014c90a9c987f64545abc6a536b9bd2435eb5e911fdfde2f13be96ea36ad38df4ae9ea387b29cced599af777338af2794820c9cce43b51d2112380a35802ab7e396c97a
   Qx = 0x9362f28c4ef96453d8a2f849f21e881cd7566887da8beb4a
   Qy = 0xe64d26d8d74c48a024ae85d982ee74cd16046f4ee5333905
   R = 0xf3923476a296c88287e8de914b0b324ad5a963319a4fe73b
   S = 0xf0baeed7624ed00d15244d8ba2aede085517dbdec8ac65f5
-  test_signature_validity( Msg, Qx, Qy, R, S, True )
+  test_signature_validity(Msg, Qx, Qy, R, S, True)
 
   Msg = 0xb2b94e4432267c92f9fdb9dc6040c95ffa477652761290d3c7de312283f6450d89cc4aabe748554dfb6056b2d8e99c7aeaad9cdddebdee9dbc099839562d9064e68e7bb5f3a6bba0749ca9a538181fc785553a4000785d73cc207922f63e8ce1112768cb1de7b673aed83a1e4a74592f1268d8e2a4e9e63d414b5d442bd0456d
   Qx = 0xcc6fc032a846aaac25533eb033522824f94e670fa997ecef
   Qy = 0xe25463ef77a029eccda8b294fd63dd694e38d223d30862f1
   R = 0x066b1d07f3a40e679b620eda7f550842a35c18b80c5ebe06
   S = 0xa0b0fb201e8f2df65e2c4508ef303bdc90d934016f16b2dc
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x4366fcadf10d30d086911de30143da6f579527036937007b337f7282460eae5678b15cccda853193ea5fc4bc0a6b9d7a31128f27e1214988592827520b214eed5052f7775b750b0c6b15f145453ba3fee24a085d65287e10509eb5d5f602c440341376b95c24e5c4727d4b859bfe1483d20538acdd92c7997fa9c614f0f839d7
   Qx = 0x955c908fe900a996f7e2089bee2f6376830f76a19135e753
   Qy = 0xba0c42a91d3847de4a592a46dc3fdaf45a7cc709b90de520
   R = 0x1f58ad77fc04c782815a1405b0925e72095d906cbf52a668
   S = 0xf2e93758b3af75edf784f05a6761c9b9a6043c66b845b599
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x543f8af57d750e33aa8565e0cae92bfa7a1ff78833093421c2942cadf9986670a5ff3244c02a8225e790fbf30ea84c74720abf99cfd10d02d34377c3d3b41269bea763384f372bb786b5846f58932defa68023136cd571863b304886e95e52e7877f445b9364b3f06f3c28da12707673fecb4b8071de06b6e0a3c87da160cef3
   Qx = 0x31f7fa05576d78a949b24812d4383107a9a45bb5fccdd835
   Qy = 0x8dc0eb65994a90f02b5e19bd18b32d61150746c09107e76b
   R = 0xbe26d59e4e883dde7c286614a767b31e49ad88789d3a78ff
   S = 0x8762ca831c1ce42df77893c9b03119428e7a9b819b619068
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0xd2e8454143ce281e609a9d748014dcebb9d0bc53adb02443a6aac2ffe6cb009f387c346ecb051791404f79e902ee333ad65e5c8cb38dc0d1d39a8dc90add5023572720e5b94b190d43dd0d7873397504c0c7aef2727e628eb6a74411f2e400c65670716cb4a815dc91cbbfeb7cfe8c929e93184c938af2c078584da045e8f8d1
   Qx = 0x66aa8edbbdb5cf8e28ceb51b5bda891cae2df84819fe25c0
   Qy = 0x0c6bc2f69030a7ce58d4a00e3b3349844784a13b8936f8da
   R = 0xa4661e69b1734f4a71b788410a464b71e7ffe42334484f23
   S = 0x738421cf5e049159d69c57a915143e226cac8355e149afe9
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   Msg = 0x6660717144040f3e2f95a4e25b08a7079c702a8b29babad5a19a87654bc5c5afa261512a11b998a4fb36b5d8fe8bd942792ff0324b108120de86d63f65855e5461184fc96a0a8ffd2ce6d5dfb0230cbbdd98f8543e361b3205f5da3d500fdc8bac6db377d75ebef3cb8f4d1ff738071ad0938917889250b41dd1d98896ca06fb
   Qx = 0xbcfacf45139b6f5f690a4c35a5fffa498794136a2353fc77
   Qy = 0x6f4a6c906316a6afc6d98fe1f0399d056f128fe0270b0f22
   R = 0x9db679a3dafe48f7ccad122933acfe9da0970b71c94c21c1
   S = 0x984c2db99827576c0a41a5da41e07d8cc768bc82f18c9da9
-  test_signature_validity( Msg, Qx, Qy, R, S, False )
-
-
+  test_signature_validity(Msg, Qx, Qy, R, S, False)
 
   print_("Testing the example code:")
 
@@ -551,24 +552,24 @@ def __main__():
 
   randrange = random.SystemRandom().randrange
 
-  secret = randrange( 1, n )
-  pubkey = Public_key( g, g * secret )
-  privkey = Private_key( pubkey, secret )
+  secret = randrange(1, n)
+  pubkey = Public_key(g, g * secret)
+  privkey = Private_key(pubkey, secret)
 
   # Signing a hash value:
 
-  hash = randrange( 1, n )
-  signature = privkey.sign( hash, randrange( 1, n ) )
+  hash = randrange(1, n)
+  signature = privkey.sign(hash, randrange(1, n))
 
   # Verifying a signature for a hash value:
 
-  if pubkey.verifies( hash, signature ):
+  if pubkey.verifies(hash, signature):
     print_("Demo verification succeeded.")
   else:
     raise TestFailure("*** Demo verification failed.")
 
-  if pubkey.verifies( hash-1, signature ):
-    raise TestFailure( "**** Demo verification failed to reject tampered hash.")
+  if pubkey.verifies(hash - 1, signature):
+    raise TestFailure("**** Demo verification failed to reject tampered hash.")
   else:
     print_("Demo verification correctly rejected tampered hash.")
 

--- a/ecdsa/ellipticcurve.py
+++ b/ecdsa/ellipticcurve.py
@@ -37,43 +37,45 @@ from __future__ import division
 from .six import print_
 from . import numbertheory
 
-class CurveFp( object ):
+
+class CurveFp(object):
   """Elliptic Curve over the field of integers modulo a prime."""
-  def __init__( self, p, a, b ):
+  def __init__(self, p, a, b):
     """The curve of points satisfying y^2 = x^3 + a*x + b (mod p)."""
     self.__p = p
     self.__a = a
     self.__b = b
 
-  def p( self ):
+  def p(self):
     return self.__p
 
-  def a( self ):
+  def a(self):
     return self.__a
 
-  def b( self ):
+  def b(self):
     return self.__b
 
-  def contains_point( self, x, y ):
+  def contains_point(self, x, y):
     """Is the point (x,y) on this curve?"""
-    return ( y * y - ( x * x * x + self.__a * x + self.__b ) ) % self.__p == 0
+    return (y * y - (x * x * x + self.__a * x + self.__b)) % self.__p == 0
 
 
-
-class Point( object ):
+class Point(object):
   """A point on an elliptic curve. Altering x and y is forbidding,
      but they can be read by the x() and y() methods."""
-  def __init__( self, curve, x, y, order = None ):
+  def __init__(self, curve, x, y, order=None):
     """curve, x, y, order; order (optional) is the order of this point."""
     self.__curve = curve
     self.__x = x
     self.__y = y
     self.__order = order
     # self.curve is allowed to be None only for INFINITY:
-    if self.__curve: assert self.__curve.contains_point( x, y )
-    if order: assert self * order == INFINITY
+    if self.__curve:
+      assert self.__curve.contains_point(x, y)
+    if order:
+      assert self * order == INFINITY
 
-  def __eq__( self, other ):
+  def __eq__(self, other):
     """Return True if the points are identical, False otherwise."""
     if self.__curve == other.__curve \
        and self.__x == other.__x \
@@ -82,71 +84,80 @@ class Point( object ):
     else:
       return False
 
-  def __add__( self, other ):
+  def __add__(self, other):
     """Add one point to another point."""
 
     # X9.62 B.3:
 
-    if other == INFINITY: return self
-    if self == INFINITY: return other
+    if other == INFINITY:
+      return self
+    if self == INFINITY:
+      return other
     assert self.__curve == other.__curve
     if self.__x == other.__x:
-      if ( self.__y + other.__y ) % self.__curve.p() == 0:
+      if (self.__y + other.__y) % self.__curve.p() == 0:
         return INFINITY
       else:
         return self.double()
 
     p = self.__curve.p()
 
-    l = ( ( other.__y - self.__y ) * \
-          numbertheory.inverse_mod( other.__x - self.__x, p ) ) % p
+    l = ((other.__y - self.__y) * \
+         numbertheory.inverse_mod(other.__x - self.__x, p)) % p
 
-    x3 = ( l * l - self.__x - other.__x ) % p
-    y3 = ( l * ( self.__x - x3 ) - self.__y ) % p
+    x3 = (l * l - self.__x - other.__x) % p
+    y3 = (l * (self.__x - x3) - self.__y) % p
 
-    return Point( self.__curve, x3, y3 )
+    return Point(self.__curve, x3, y3)
 
-  def __mul__( self, other ):
+  def __mul__(self, other):
     """Multiply a point by an integer."""
 
-    def leftmost_bit( x ):
+    def leftmost_bit(x):
       assert x > 0
       result = 1
-      while result <= x: result = 2 * result
+      while result <= x:
+        result = 2 * result
       return result // 2
 
     e = other
-    if self.__order: e = e % self.__order
-    if e == 0: return INFINITY
-    if self == INFINITY: return INFINITY
+    if self.__order:
+      e = e % self.__order
+    if e == 0:
+      return INFINITY
+    if self == INFINITY:
+      return INFINITY
     assert e > 0
 
     # From X9.62 D.3.2:
 
     e3 = 3 * e
-    negative_self = Point( self.__curve, self.__x, -self.__y, self.__order )
-    i = leftmost_bit( e3 ) // 2
+    negative_self = Point(self.__curve, self.__x, -self.__y, self.__order)
+    i = leftmost_bit(e3) // 2
     result = self
-    # print_("Multiplying %s by %d (e3 = %d):" % ( self, other, e3 ))
+    # print_("Multiplying %s by %d (e3 = %d):" % (self, other, e3))
     while i > 1:
       result = result.double()
-      if ( e3 & i ) != 0 and ( e & i ) == 0: result = result + self
-      if ( e3 & i ) == 0 and ( e & i ) != 0: result = result + negative_self
+      if (e3 & i) != 0 and (e & i) == 0:
+        result = result + self
+      if (e3 & i) == 0 and (e & i) != 0:
+        result = result + negative_self
       # print_(". . . i = %d, result = %s" % ( i, result ))
       i = i // 2
 
     return result
 
-  def __rmul__( self, other ):
+  def __rmul__(self, other):
     """Multiply a point by an integer."""
 
     return self * other
 
-  def __str__( self ):
-    if self == INFINITY: return "infinity"
-    return "(%d,%d)" % ( self.__x, self.__y )
+  def __str__(self):
+    if self == INFINITY:
+      return "infinity"
+    return "(%d,%d)" % (self.__x, self.__y)
 
-  def double( self ):
+  def double(self):
     """Return a new point that is twice the old."""
 
     if self == INFINITY:
@@ -157,93 +168,95 @@ class Point( object ):
     p = self.__curve.p()
     a = self.__curve.a()
 
-    l = ( ( 3 * self.__x * self.__x + a ) * \
-          numbertheory.inverse_mod( 2 * self.__y, p ) ) % p
+    l = ((3 * self.__x * self.__x + a) * \
+         numbertheory.inverse_mod(2 * self.__y, p)) % p
 
-    x3 = ( l * l - 2 * self.__x ) % p
-    y3 = ( l * ( self.__x - x3 ) - self.__y ) % p
+    x3 = (l * l - 2 * self.__x) % p
+    y3 = (l * (self.__x - x3) - self.__y) % p
 
-    return Point( self.__curve, x3, y3 )
+    return Point(self.__curve, x3, y3)
 
-  def x( self ):
+  def x(self):
     return self.__x
 
-  def y( self ):
+  def y(self):
     return self.__y
 
-  def curve( self ):
+  def curve(self):
     return self.__curve
 
-  def order( self ):
+  def order(self):
     return self.__order
 
 
 # This one point is the Point At Infinity for all purposes:
-INFINITY = Point( None, None, None )
+INFINITY = Point(None, None, None)
+
 
 def __main__():
 
-  class FailedTest(Exception): pass
-  def test_add( c, x1, y1, x2,  y2, x3, y3 ):
+  class FailedTest(Exception):
+    pass
+
+  def test_add(c, x1, y1, x2, y2, x3, y3):
     """We expect that on curve c, (x1,y1) + (x2, y2 ) = (x3, y3)."""
-    p1 = Point( c, x1, y1 )
-    p2 = Point( c, x2, y2 )
+    p1 = Point(c, x1, y1)
+    p2 = Point(c, x2, y2)
     p3 = p1 + p2
-    print_("%s + %s = %s" % ( p1, p2, p3 ), end=' ')
+    print_("%s + %s = %s" % (p1, p2, p3), end=' ')
     if p3.x() != x3 or p3.y() != y3:
-      raise FailedTest("Failure: should give (%d,%d)." % ( x3, y3 ))
+      raise FailedTest("Failure: should give (%d,%d)." % (x3, y3))
     else:
       print_(" Good.")
 
-  def test_double( c, x1, y1, x3, y3 ):
+  def test_double(c, x1, y1, x3, y3):
     """We expect that on curve c, 2*(x1,y1) = (x3, y3)."""
-    p1 = Point( c, x1, y1 )
+    p1 = Point(c, x1, y1)
     p3 = p1.double()
-    print_("%s doubled = %s" % ( p1, p3 ), end=' ')
+    print_("%s doubled = %s" % (p1, p3), end=' ')
     if p3.x() != x3 or p3.y() != y3:
-      raise FailedTest("Failure: should give (%d,%d)." % ( x3, y3 ))
+      raise FailedTest("Failure: should give (%d,%d)." % (x3, y3))
     else:
       print_(" Good.")
 
-  def test_double_infinity( c ):
+  def test_double_infinity(c):
     """We expect that on curve c, 2*INFINITY = INFINITY."""
     p1 = INFINITY
     p3 = p1.double()
-    print_("%s doubled = %s" % ( p1, p3 ), end=' ')
+    print_("%s doubled = %s" % (p1, p3), end=' ')
     if p3.x() != INFINITY.x() or p3.y() != INFINITY.y():
-      raise FailedTest("Failure: should give (%d,%d)." % ( INFINITY.x(), INFINITY.y() ))
+      raise FailedTest("Failure: should give (%d,%d)." % (INFINITY.x(), INFINITY.y()))
     else:
       print_(" Good.")
 
-  def test_multiply( c, x1, y1, m, x3, y3 ):
+  def test_multiply(c, x1, y1, m, x3, y3):
     """We expect that on curve c, m*(x1,y1) = (x3,y3)."""
-    p1 = Point( c, x1, y1 )
+    p1 = Point(c, x1, y1)
     p3 = p1 * m
-    print_("%s * %d = %s" % ( p1, m, p3 ), end=' ')
+    print_("%s * %d = %s" % (p1, m, p3), end=' ')
     if p3.x() != x3 or p3.y() != y3:
-      raise FailedTest("Failure: should give (%d,%d)." % ( x3, y3 ))
+      raise FailedTest("Failure: should give (%d,%d)." % (x3, y3))
     else:
       print_(" Good.")
-
 
   # A few tests from X9.62 B.3:
 
-  c = CurveFp( 23, 1, 1 )
-  test_add( c, 3, 10, 9, 7, 17, 20 )
-  test_double( c, 3, 10, 7, 12 )
-  test_add( c, 3, 10, 3, 10, 7, 12 )	# (Should just invoke double.)
-  test_multiply( c, 3, 10, 2, 7, 12 )
+  c = CurveFp(23, 1, 1)
+  test_add(c, 3, 10, 9, 7, 17, 20)
+  test_double(c, 3, 10, 7, 12)
+  test_add(c, 3, 10, 3, 10, 7, 12)  # (Should just invoke double.)
+  test_multiply(c, 3, 10, 2, 7, 12)
 
   test_double_infinity(c)
 
   # From X9.62 I.1 (p. 96):
 
-  g = Point( c, 13, 7, 7 )
+  g = Point(c, 13, 7, 7)
 
   check = INFINITY
-  for i in range( 7 + 1 ):
-    p = ( i % 7 ) * g
-    print_("%s * %d = %s, expected %s . . ." % ( g, i, p, check ), end=' ')
+  for i in range(7 + 1):
+    p = (i % 7) * g
+    print_("%s * %d = %s, expected %s . . ." % (g, i, p, check), end=' ')
     if p == check:
       print_(" Good.")
     else:
@@ -253,14 +266,14 @@ def __main__():
   # NIST Curve P-192:
   p = 6277101735386680763835789423207666416083908700390324961279
   r = 6277101735386680763835789423176059013767194773182842284081
-  #s = 0x3045ae6fc8422f64ed579528d38120eae12196d5L
+  # s = 0x3045ae6fc8422f64ed579528d38120eae12196d5L
   c = 0x3099d2bbbfcb2538542dcd5fb078b6ef5f3d6fe2c745de65
   b = 0x64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1
   Gx = 0x188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012
   Gy = 0x07192b95ffc8da78631011ed6b24cdd573f977a11e794811
 
-  c192 = CurveFp( p, -3, b )
-  p192 = Point( c192, Gx, Gy, r )
+  c192 = CurveFp(p, -3, b)
+  p192 = Point(c192, Gx, Gy, r)
 
   # Checking against some sample computations presented
   # in X9.62:

--- a/ecdsa/keys.py
+++ b/ecdsa/keys.py
@@ -10,10 +10,14 @@ from .util import oid_ecPublicKey, encoded_oid_ecPublicKey
 from .six import PY3, b
 from hashlib import sha1
 
+
 class BadSignatureError(Exception):
     pass
+
+
 class BadDigestError(Exception):
     pass
+
 
 class VerifyingKey:
     def __init__(self, _error__please_use_generate=None):
@@ -33,7 +37,7 @@ class VerifyingKey:
     def from_string(klass, string, curve=NIST192p, hashfunc=sha1,
                     validate_point=True):
         order = curve.order
-        assert len(string) == curve.verifying_key_length, \
+        assert (len(string) == curve.verifying_key_length), \
                (len(string), curve.verifying_key_length)
         xs = string[:curve.baselen]
         ys = string[curve.baselen:]
@@ -54,11 +58,11 @@ class VerifyingKey:
     @classmethod
     def from_der(klass, string):
         # [[oid_ecPublicKey,oid_curve], point_str_bitstring]
-        s1,empty = der.remove_sequence(string)
+        s1, empty = der.remove_sequence(string)
         if empty != b(""):
             raise der.UnexpectedDER("trailing junk after DER pubkey: %s" %
                                     binascii.hexlify(empty))
-        s2,point_str_bitstring = der.remove_sequence(s1)
+        s2, point_str_bitstring = der.remove_sequence(s1)
         # s2 = oid_ecPublicKey,oid_curve
         oid_pk, rest = der.remove_object(s2)
         oid_curve, empty = der.remove_object(rest)
@@ -104,13 +108,14 @@ class VerifyingKey:
         if len(digest) > self.curve.baselen:
             raise BadDigestError("this curve (%s) is too short "
                                  "for your digest (%d)" % (self.curve.name,
-                                                           8*len(digest)))
+                                                           8 * len(digest)))
         number = string_to_number(digest)
         r, s = sigdecode(signature, self.pubkey.order)
         sig = ecdsa.Signature(r, s)
         if self.pubkey.verifies(number, sig):
             return True
         raise BadSignatureError
+
 
 class SigningKey:
     def __init__(self, _error__please_use_generate=None):
@@ -135,7 +140,7 @@ class SigningKey:
         self.baselen = curve.baselen
         n = curve.order
         assert 1 <= secexp < n
-        pubkey_point = curve.generator*secexp
+        pubkey_point = curve.generator * secexp
         pubkey = ecdsa.Public_key(curve.generator, pubkey_point)
         pubkey.order = n
         self.verifying_key = VerifyingKey.from_public_point(pubkey_point, curve,
@@ -158,6 +163,7 @@ class SigningKey:
             string = string.encode()
         privkey_pem = string[string.index(b("-----BEGIN EC PRIVATE KEY-----")):]
         return klass.from_der(der.unpem(privkey_pem), hashfunc)
+
     @classmethod
     def from_der(klass, string, hashfunc=sha1):
         # SEQ([int(1), octetstring(privkey),cont[0], oid(secp224r1),
@@ -183,18 +189,18 @@ class SigningKey:
 
         # we don't actually care about the following fields
         #
-        #tag, pubkey_bitstring, s = der.remove_constructed(s)
-        #if tag != 1:
-        #    raise der.UnexpectedDER("expected tag 1 in DER privkey, got %d"
-        #                            % tag)
-        #pubkey_str = der.remove_bitstring(pubkey_bitstring)
-        #if empty != "":
-        #    raise der.UnexpectedDER("trailing junk after DER privkey "
-        #                            "pubkeystr: %s" % binascii.hexlify(empty))
+        # tag, pubkey_bitstring, s = der.remove_constructed(s)
+        # if tag != 1:
+        #     raise der.UnexpectedDER("expected tag 1 in DER privkey, got %d"
+        #                             % tag)
+        # pubkey_str = der.remove_bitstring(pubkey_bitstring)
+        # if empty != "":
+        #     raise der.UnexpectedDER("trailing junk after DER privkey "
+        #                             "pubkeystr: %s" % binascii.hexlify(empty))
 
         # our from_string method likes fixed-length privkey strings
         if len(privkey_str) < curve.baselen:
-            privkey_str = b("\x00")*(curve.baselen-len(privkey_str)) + privkey_str
+            privkey_str = b("\x00") * (curve.baselen - len(privkey_str)) + privkey_str
         return klass.from_string(privkey_str, curve, hashfunc)
 
     def to_string(self):
@@ -258,7 +264,7 @@ class SigningKey:
         if len(digest) > self.curve.baselen:
             raise BadDigestError("this curve (%s) is too short "
                                  "for your digest (%d)" % (self.curve.name,
-                                                           8*len(digest)))
+                                                           8 * len(digest)))
         number = string_to_number(digest)
         r, s = self.sign_number(number, entropy, k)
         return sigencode(r, s, self.privkey.order)

--- a/ecdsa/numbertheory.py
+++ b/ecdsa/numbertheory.py
@@ -6,7 +6,7 @@
 #
 # Written in 2005 and 2006 by Peter Pearson and placed in the public domain.
 # Revision history:
-#   2008.11.14: Use pow( base, exponent, modulus ) for modular_exp.
+#   2008.11.14: Use pow(base, exponent, modulus) for modular_exp.
 #               Make gcd and lcm accept arbitrarly many arguments.
 
 from __future__ import division
@@ -17,34 +17,36 @@ from .six.moves import reduce
 import math
 
 
-class Error( Exception ):
+class Error(Exception):
   """Base class for exceptions in this module."""
   pass
 
-class SquareRootError( Error ):
+
+class SquareRootError(Error):
   pass
 
-class NegativeExponentError( Error ):
+
+class NegativeExponentError(Error):
   pass
 
 
-def modular_exp( base, exponent, modulus ):
+def modular_exp(base, exponent, modulus):
   "Raise base to exponent, reducing by modulus"
   if exponent < 0:
-    raise NegativeExponentError( "Negative exponents (%d) not allowed" \
-                                 % exponent )
-  return pow( base, exponent, modulus )
+    raise NegativeExponentError("Negative exponents (%d) not allowed" \
+                                % exponent)
+  return pow(base, exponent, modulus)
 #   result = 1L
 #   x = exponent
 #   b = base + 0L
 #   while x > 0:
 #     if x % 2 > 0: result = (result * b) % modulus
 #     x = x // 2
-#     b = ( b * b ) % modulus
+#     b = (b * b) % modulus
 #   return result
 
 
-def polynomial_reduce_mod( poly, polymod, p ):
+def polynomial_reduce_mod(poly, polymod, p):
   """Reduce poly by polymod, integer arithmetic modulo p.
 
   Polynomials are represented as lists of coefficients
@@ -56,19 +58,18 @@ def polynomial_reduce_mod( poly, polymod, p ):
   # Just to make this easy, require a monic polynomial:
   assert polymod[-1] == 1
 
-  assert len( polymod ) > 1
+  assert len(polymod) > 1
 
-  while len( poly ) >= len( polymod ):
+  while len(poly) >= len(polymod):
     if poly[-1] != 0:
-      for i in range( 2, len( polymod ) + 1 ):
-        poly[-i] = ( poly[-i] - poly[-1] * polymod[-i] ) % p
+      for i in range(2, len(polymod) + 1):
+        poly[-i] = (poly[-i] - poly[-1] * polymod[-i]) % p
     poly = poly[0:-1]
 
   return poly
 
 
-
-def polynomial_multiply_mod( m1, m2, polymod, p ):
+def polynomial_multiply_mod(m1, m2, polymod, p):
   """Polynomial multiplication modulo a polynomial over ints mod p.
 
   Polynomials are represented as lists of coefficients
@@ -81,18 +82,18 @@ def polynomial_multiply_mod( m1, m2, polymod, p ):
 
   # Initialize the product to zero:
 
-  prod = ( len( m1 ) + len( m2 ) - 1 ) * [0]
+  prod = (len(m1) + len(m2) - 1) * [0]
 
   # Add together all the cross-terms:
 
-  for i in range( len( m1 ) ):
-    for j in range( len( m2 ) ):
-      prod[i+j] = ( prod[i+j] + m1[i] * m2[j] ) % p
+  for i in range(len(m1)):
+    for j in range(len(m2)):
+      prod[i + j] = (prod[i + j] + m1[i] * m2[j]) % p
 
-  return polynomial_reduce_mod( prod, polymod, p )
+  return polynomial_reduce_mod(prod, polymod, p)
 
 
-def polynomial_exp_mod( base, exponent, polymod, p ):
+def polynomial_exp_mod(base, exponent, polymod, p):
   """Polynomial exponentiation modulo a polynomial over ints mod p.
 
   Polynomials are represented as lists of coefficients
@@ -105,23 +106,26 @@ def polynomial_exp_mod( base, exponent, polymod, p ):
 
   assert exponent < p
 
-  if exponent == 0: return [ 1 ]
+  if exponent == 0:
+    return [1]
 
   G = base
   k = exponent
-  if k%2 == 1: s = G
-  else:        s = [ 1 ]
+  if k % 2 == 1:
+    s = G
+  else:
+    s = [1]
 
   while k > 1:
     k = k // 2
-    G = polynomial_multiply_mod( G, G, polymod, p )
-    if k%2 == 1: s = polynomial_multiply_mod( G, s, polymod, p )
+    G = polynomial_multiply_mod(G, G, polymod, p)
+    if k % 2 == 1:
+      s = polynomial_multiply_mod(G, s, polymod, p)
 
   return s
 
 
-
-def jacobi( a, n ):
+def jacobi(a, n):
   """Jacobi symbol"""
 
   # Based on the Handbook of Applied Cryptography (HAC), algorithm 2.149.
@@ -131,22 +135,27 @@ def jacobi( a, n ):
   # modular square roots.
 
   assert n >= 3
-  assert n%2 == 1
+  assert n % 2 == 1
   a = a % n
-  if a == 0: return 0
-  if a == 1: return 1
+  if a == 0:
+    return 0
+  if a == 1:
+    return 1
   a1, e = a, 0
-  while a1%2 == 0:
-    a1, e = a1//2, e+1
-  if e%2 == 0 or n%8 == 1 or n%8 == 7: s = 1
-  else: s = -1
-  if a1 == 1: return s
-  if n%4 == 3 and a1%4 == 3: s = -s
-  return s * jacobi( n % a1, a1 )
+  while a1 % 2 == 0:
+    a1, e = a1 // 2, e + 1
+  if e % 2 == 0 or n % 8 == 1 or n % 8 == 7:
+    s = 1
+  else:
+    s = -1
+  if a1 == 1:
+    return s
+  if n % 4 == 3 and a1 % 4 == 3:
+    s = -s
+  return s * jacobi(n % a1, a1)
 
 
-
-def square_root_mod_prime( a, p ):
+def square_root_mod_prime(a, p):
   """Modular square root of a, mod p, p prime."""
 
   # Based on the Handbook of Applied Cryptography, algorithms 3.34 to 3.39.
@@ -157,96 +166,108 @@ def square_root_mod_prime( a, p ):
   assert 0 <= a < p
   assert 1 < p
 
-  if a == 0: return 0
-  if p == 2: return a
+  if a == 0:
+    return 0
+  if p == 2:
+    return a
 
-  jac = jacobi( a, p )
-  if jac == -1: raise SquareRootError( "%d has no square root modulo %d" \
-                                       % ( a, p ) )
+  jac = jacobi(a, p)
+  if jac == -1:
+    raise SquareRootError("%d has no square root modulo %d" \
+                          % (a, p))
 
-  if p % 4 == 3: return modular_exp( a, (p+1)//4, p )
+  if p % 4 == 3:
+    return modular_exp(a, (p + 1) // 4, p)
 
   if p % 8 == 5:
-    d = modular_exp( a, (p-1)//4, p )
-    if d == 1: return modular_exp( a, (p+3)//8, p )
-    if d == p-1: return ( 2 * a * modular_exp( 4*a, (p-5)//8, p ) ) % p
+    d = modular_exp(a, (p - 1) // 4, p)
+    if d == 1:
+      return modular_exp(a, (p + 3) // 8, p)
+    if d == p - 1:
+      return (2 * a * modular_exp(4 * a, (p - 5) // 8, p)) % p
     raise RuntimeError("Shouldn't get here.")
 
-  for b in range( 2, p ):
-    if jacobi( b*b-4*a, p ) == -1:
-      f = ( a, -b, 1 )
-      ff = polynomial_exp_mod( ( 0, 1 ), (p+1)//2, f, p )
+  for b in range(2, p):
+    if jacobi(b * b - 4 * a, p) == -1:
+      f = (a, -b, 1)
+      ff = polynomial_exp_mod((0, 1), (p + 1) // 2, f, p)
       assert ff[1] == 0
       return ff[0]
   raise RuntimeError("No b found.")
 
 
-
-def inverse_mod( a, m ):
+def inverse_mod(a, m):
   """Inverse of a mod m."""
 
-  if a < 0 or m <= a: a = a % m
+  if a < 0 or m <= a:
+    a = a % m
 
   # From Ferguson and Schneier, roughly:
 
   c, d = a, m
   uc, vc, ud, vd = 1, 0, 0, 1
   while c != 0:
-    q, c, d = divmod( d, c ) + ( c, )
-    uc, vc, ud, vd = ud - q*uc, vd - q*vc, uc, vc
+    q, c, d = divmod(d, c) + (c,)
+    uc, vc, ud, vd = ud - q * uc, vd - q * vc, uc, vc
 
   # At this point, d is the GCD, and ud*a+vd*m = d.
   # If d == 1, this means that ud is a inverse.
 
   assert d == 1
-  if ud > 0: return ud
-  else: return ud + m
+  if ud > 0:
+    return ud
+  else:
+    return ud + m
 
 
 def gcd2(a, b):
   """Greatest common divisor using Euclid's algorithm."""
   while a:
-    a, b = b%a, a
+    a, b = b % a, a
   return b
 
 
-def gcd( *a ):
+def gcd(*a):
   """Greatest common divisor.
 
-  Usage: gcd( [ 2, 4, 6 ] )
-  or:    gcd( 2, 4, 6 )
+  Usage: gcd([ 2, 4, 6 ])
+  or:    gcd(2, 4, 6)
   """
 
-  if len( a ) > 1: return reduce( gcd2, a )
-  if hasattr( a[0], "__iter__" ): return reduce( gcd2, a[0] )
+  if len(a) > 1:
+    return reduce(gcd2, a)
+  if hasattr(a[0], "__iter__"):
+    return reduce(gcd2, a[0])
   return a[0]
 
 
-def lcm2(a,b):
+def lcm2(a, b):
   """Least common multiple of two integers."""
 
-  return (a*b)//gcd(a,b)
+  return (a * b) // gcd(a, b)
 
 
-def lcm( *a ):
+def lcm(*a):
   """Least common multiple.
 
-  Usage: lcm( [ 3, 4, 5 ] )
-  or:    lcm( 3, 4, 5 )
+  Usage: lcm([ 3, 4, 5 ])
+  or:    lcm(3, 4, 5)
   """
 
-  if len( a ) > 1: return reduce( lcm2, a )
-  if hasattr( a[0], "__iter__" ): return reduce( lcm2, a[0] )
+  if len(a) > 1:
+    return reduce(lcm2, a)
+  if hasattr(a[0], "__iter__"):
+    return reduce(lcm2, a[0])
   return a[0]
 
 
-
-def factorization( n ):
+def factorization(n):
   """Decompose n into a list of (prime,exponent) pairs."""
 
-  assert isinstance( n, integer_types )
+  assert isinstance(n, integer_types)
 
-  if n < 2: return []
+  if n < 2:
+    return []
 
   result = []
   d = 2
@@ -254,139 +275,149 @@ def factorization( n ):
   # Test the small primes:
 
   for d in smallprimes:
-    if d > n: break
-    q, r = divmod( n, d )
+    if d > n:
+      break
+    q, r = divmod(n, d)
     if r == 0:
       count = 1
       while d <= n:
         n = q
-        q, r = divmod( n, d )
-        if r != 0: break
+        q, r = divmod(n, d)
+        if r != 0:
+          break
         count = count + 1
-      result.append( ( d, count ) )
+      result.append((d, count))
 
   # If n is still greater than the last of our small primes,
   # it may require further work:
 
   if n > smallprimes[-1]:
-    if is_prime( n ):   # If what's left is prime, it's easy:
-      result.append( ( n, 1 ) )
+    if is_prime(n):   # If what's left is prime, it's easy:
+      result.append((n, 1))
     else:               # Ugh. Search stupidly for a divisor:
       d = smallprimes[-1]
       while 1:
         d = d + 2               # Try the next divisor.
-        q, r = divmod( n, d )
-        if q < d: break         # n < d*d means we're done, n = 1 or prime.
+        q, r = divmod(n, d)
+        if q < d:               # n < d*d means we're done, n = 1 or prime.
+          break
         if r == 0:              # d divides n. How many times?
           count = 1
           n = q
-          while d <= n:                 # As long as d might still divide n,
-            q, r = divmod( n, d )       # see if it does.
-            if r != 0: break
-            n = q                       # It does. Reduce n, increase count.
+          while d <= n:               # As long as d might still divide n,
+            q, r = divmod(n, d)       # see if it does.
+            if r != 0:
+              break
+            n = q                     # It does. Reduce n, increase count.
             count = count + 1
-          result.append( ( d, count ) )
-      if n > 1: result.append( ( n, 1 ) )
+          result.append((d, count))
+      if n > 1:
+        result.append((n, 1))
 
   return result
 
 
-
-def phi( n ):
+def phi(n):
   """Return the Euler totient function of n."""
 
-  assert isinstance( n, integer_types )
+  assert isinstance(n, integer_types)
 
-  if n < 3: return 1
+  if n < 3:
+    return 1
 
   result = 1
-  ff = factorization( n )
+  ff = factorization(n)
   for f in ff:
     e = f[1]
     if e > 1:
-      result = result * f[0] ** (e-1) * ( f[0] - 1 )
+      result = result * f[0] ** (e - 1) * (f[0] - 1)
     else:
-      result = result * ( f[0] - 1 )
+      result = result * (f[0] - 1)
   return result
 
 
-def carmichael( n ):
+def carmichael(n):
   """Return Carmichael function of n.
 
   Carmichael(n) is the smallest integer x such that
   m**x = 1 mod n for all m relatively prime to n.
   """
 
-  return carmichael_of_factorized( factorization( n ) )
+  return carmichael_of_factorized(factorization(n))
 
 
-def carmichael_of_factorized( f_list ):
+def carmichael_of_factorized(f_list):
   """Return the Carmichael function of a number that is
   represented as a list of (prime,exponent) pairs.
   """
 
-  if len( f_list ) < 1: return 1
+  if len(f_list) < 1:
+    return 1
 
-  result = carmichael_of_ppower( f_list[0] )
-  for i in range( 1, len( f_list ) ):
-    result = lcm( result, carmichael_of_ppower( f_list[i] ) )
+  result = carmichael_of_ppower(f_list[0])
+  for i in range(1, len(f_list)):
+    result = lcm(result, carmichael_of_ppower(f_list[i]))
 
   return result
 
-def carmichael_of_ppower( pp ):
+
+def carmichael_of_ppower(pp):
   """Carmichael function of the given power of the given prime.
   """
 
   p, a = pp
-  if p == 2 and a > 2: return 2**(a-2)
-  else: return (p-1) * p**(a-1)
+  if p == 2 and a > 2:
+    return 2**(a - 2)
+  else:
+    return (p - 1) * p**(a - 1)
 
 
-
-def order_mod( x, m ):
+def order_mod(x, m):
   """Return the order of x in the multiplicative group mod m.
   """
 
   # Warning: this implementation is not very clever, and will
   # take a long time if m is very large.
 
-  if m <= 1: return 0
+  if m <= 1:
+    return 0
 
-  assert gcd( x, m ) == 1
+  assert gcd(x, m) == 1
 
   z = x
   result = 1
   while z != 1:
-    z = ( z * x ) % m
+    z = (z * x) % m
     result = result + 1
   return result
 
 
-def largest_factor_relatively_prime( a, b ):
+def largest_factor_relatively_prime(a, b):
   """Return the largest factor of a relatively prime to b.
   """
 
   while 1:
-    d = gcd( a, b )
-    if d <= 1: break
+    d = gcd(a, b)
+    if d <= 1:
+      break
     b = d
     while 1:
-      q, r = divmod( a, d )
+      q, r = divmod(a, d)
       if r > 0:
         break
       a = q
   return a
 
 
-def kinda_order_mod( x, m ):
+def kinda_order_mod(x, m):
   """Return the order of x in the multiplicative group mod m',
   where m' is the largest factor of m relatively prime to x.
   """
 
-  return order_mod( x, largest_factor_relatively_prime( m, x ) )
+  return order_mod(x, largest_factor_relatively_prime(m, x))
 
 
-def is_prime( n ):
+def is_prime(n):
   """Return True if x is prime, False otherwise.
 
   We use the Miller-Rabin test, as given in Menezes et al. p. 138.
@@ -408,63 +439,69 @@ def is_prime( n ):
   miller_rabin_test_count = 0
 
   if n <= smallprimes[-1]:
-    if n in smallprimes: return True
-    else: return False
+    if n in smallprimes:
+      return True
+    else:
+      return False
 
-  if gcd( n, 2*3*5*7*11 ) != 1: return False
+  if gcd(n, 2 * 3 * 5 * 7 * 11) != 1:
+    return False
 
   # Choose a number of iterations sufficient to reduce the
   # probability of accepting a composite below 2**-80
   # (from Menezes et al. Table 4.4):
 
   t = 40
-  n_bits = 1 + int( math.log( n, 2 ) )
-  for k, tt in ( ( 100, 27 ),
-                 ( 150, 18 ),
-                 ( 200, 15 ),
-                 ( 250, 12 ),
-                 ( 300,  9 ),
-                 ( 350,  8 ),
-                 ( 400,  7 ),
-                 ( 450,  6 ),
-                 ( 550,  5 ),
-                 ( 650,  4 ),
-                 ( 850,  3 ),
-                 ( 1300, 2 ),
-                 ):
-    if n_bits < k: break
+  n_bits = 1 + int(math.log(n, 2))
+  for k, tt in ((100, 27),
+                (150, 18),
+                (200, 15),
+                (250, 12),
+                (300, 9),
+                (350, 8),
+                (400, 7),
+                (450, 6),
+                (550, 5),
+                (650, 4),
+                (850, 3),
+                (1300, 2),
+                ):
+    if n_bits < k:
+      break
     t = tt
 
   # Run the test t times:
 
   s = 0
   r = n - 1
-  while ( r % 2 ) == 0:
+  while (r % 2) == 0:
     s = s + 1
     r = r // 2
-  for i in range( t ):
-    a = smallprimes[ i ]
-    y = modular_exp( a, r, n )
-    if y != 1 and y != n-1:
+  for i in range(t):
+    a = smallprimes[i]
+    y = modular_exp(a, r, n)
+    if y != 1 and y != n - 1:
       j = 1
       while j <= s - 1 and y != n - 1:
-        y = modular_exp( y, 2, n )
+        y = modular_exp(y, 2, n)
         if y == 1:
           miller_rabin_test_count = i + 1
           return False
         j = j + 1
-      if y != n-1:
+      if y != n - 1:
         miller_rabin_test_count = i + 1
         return False
   return True
 
 
-def next_prime( starting_value ):
+def next_prime(starting_value):
   "Return the smallest prime larger than the starting value."
 
-  if starting_value < 2: return 2
-  result = ( starting_value + 1 ) | 1
-  while not is_prime( result ): result = result + 2
+  if starting_value < 2:
+    return 2
+  result = (starting_value + 1) | 1
+  while not is_prime(result):
+    result = result + 2
   return result
 
 
@@ -491,47 +528,47 @@ smallprimes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41,
 
 miller_rabin_test_count = 0
 
+
 def __main__():
 
   # Making sure locally defined exceptions work:
-  # p = modular_exp( 2, -2, 3 )
-  # p = square_root_mod_prime( 2, 3 )
-
+  # p = modular_exp(2, -2, 3)
+  # p = square_root_mod_prime(2, 3)
 
   print_("Testing gcd...")
-  assert gcd( 3*5*7, 3*5*11, 3*5*13 )     == 3*5
-  assert gcd( [ 3*5*7, 3*5*11, 3*5*13 ] ) == 3*5
-  assert gcd( 3 ) == 3
+  assert gcd(3 * 5 * 7, 3 * 5 * 11, 3 * 5 * 13) == 3 * 5
+  assert gcd([3 * 5 * 7, 3 * 5 * 11, 3 * 5 * 13]) == 3 * 5
+  assert gcd(3) == 3
 
   print_("Testing lcm...")
-  assert lcm( 3, 5*3, 7*3 )     == 3*5*7
-  assert lcm( [ 3, 5*3, 7*3 ] ) == 3*5*7
-  assert lcm( 3 ) == 3
+  assert lcm(3, 5 * 3, 7 * 3) == 3 * 5 * 7
+  assert lcm([3, 5 * 3, 7 * 3]) == 3 * 5 * 7
+  assert lcm(3) == 3
 
   print_("Testing next_prime...")
-  bigprimes = ( 999671,
-                999683,
-                999721,
-                999727,
-                999749,
-                999763,
-                999769,
-                999773,
-                999809,
-                999853,
-                999863,
-                999883,
-                999907,
-                999917,
-                999931,
-                999953,
-                999959,
-                999961,
-                999979,
-                999983 )
+  bigprimes = (999671,
+               999683,
+               999721,
+               999727,
+               999749,
+               999763,
+               999769,
+               999773,
+               999809,
+               999853,
+               999863,
+               999883,
+               999907,
+               999917,
+               999931,
+               999953,
+               999959,
+               999961,
+               999979,
+               999983)
 
-  for i in range( len( bigprimes ) - 1 ):
-    assert next_prime( bigprimes[i] ) == bigprimes[ i+1 ]
+  for i in range(len(bigprimes) - 1):
+    assert next_prime(bigprimes[i]) == bigprimes[i + 1]
 
   error_tally = 0
 
@@ -541,70 +578,72 @@ def __main__():
     print_("Testing square_root_mod_prime for modulus p = %d." % p)
     squares = []
 
-    for root in range( 0, 1+p//2 ):
-      sq = ( root * root ) % p
-      squares.append( sq )
-      calculated = square_root_mod_prime( sq, p )
-      if ( calculated * calculated ) % p != sq:
+    for root in range(0, 1 + p // 2):
+      sq = (root * root) % p
+      squares.append(sq)
+      calculated = square_root_mod_prime(sq, p)
+      if (calculated * calculated) % p != sq:
         error_tally = error_tally + 1
         print_("Failed to find %d as sqrt( %d ) mod %d. Said %d." % \
-              ( root, sq, p, calculated ))
+               (root, sq, p, calculated))
 
-    for nonsquare in range( 0, p ):
+    for nonsquare in range(0, p):
       if nonsquare not in squares:
         try:
-          calculated = square_root_mod_prime( nonsquare, p )
+          calculated = square_root_mod_prime(nonsquare, p)
         except SquareRootError:
           pass
         else:
           error_tally = error_tally + 1
           print_("Failed to report no root for sqrt( %d ) mod %d." % \
-                ( nonsquare, p ))
+                 (nonsquare, p))
 
   # Test the jacobi function:
-  for m in range( 3, 400, 2 ):
+  for m in range(3, 400, 2):
     print_("Testing jacobi for modulus m = %d." % m)
-    if is_prime( m ):
+    if is_prime(m):
       squares = []
-      for root in range( 1, m ):
-        if jacobi( root * root, m ) != 1:
+      for root in range(1, m):
+        if jacobi(root * root, m) != 1:
           error_tally = error_tally + 1
-          print_("jacobi( %d * %d, %d ) != 1" % ( root, root, m ))
-        squares.append( root * root % m )
-      for i in range( 1, m ):
-        if not i in squares:
-          if jacobi( i, m ) != -1:
+          print_("jacobi( %d * %d, %d) != 1" % (root, root, m))
+        squares.append(root * root % m)
+      for i in range(1, m):
+        if i not in squares:
+          if jacobi(i, m) != -1:
             error_tally = error_tally + 1
-            print_("jacobi( %d, %d ) != -1" % ( i, m ))
+            print_("jacobi( %d, %d ) != -1" % (i, m))
     else:       # m is not prime.
-      f = factorization( m )
-      for a in range( 1, m ):
+      f = factorization(m)
+      for a in range(1, m):
         c = 1
         for i in f:
-          c = c * jacobi( a, i[0] ) ** i[1]
-        if c != jacobi( a, m ):
+          c = c * jacobi(a, i[0]) ** i[1]
+        if c != jacobi(a, m):
           error_tally = error_tally + 1
-          print_("%d != jacobi( %d, %d )" % ( c, a, m ))
+          print_("%d != jacobi( %d, %d )" % (c, a, m))
 
 
 # Test the inverse_mod function:
   print_("Testing inverse_mod . . .")
   import random
   n_tests = 0
-  for i in range( 100 ):
-    m = random.randint( 20, 10000 )
-    for j in range( 100 ):
-      a = random.randint( 1, m-1 )
-      if gcd( a, m ) == 1:
+  for i in range(100):
+    m = random.randint(20, 10000)
+    for j in range(100):
+      a = random.randint(1, m - 1)
+      if gcd(a, m) == 1:
         n_tests = n_tests + 1
-        inv = inverse_mod( a, m )
-        if inv <= 0 or inv >= m or ( a * inv ) % m != 1:
+        inv = inverse_mod(a, m)
+        if inv <= 0 or inv >= m or (a * inv) % m != 1:
           error_tally = error_tally + 1
-          print_("%d = inverse_mod( %d, %d ) is wrong." % ( inv, a, m ))
+          print_("%d = inverse_mod( %d, %d ) is wrong." % (inv, a, m))
   assert n_tests > 1000
   print_(n_tests, " tests of inverse_mod completed.")
 
-  class FailedTest(Exception): pass
+  class FailedTest(Exception):
+    pass
+
   print_(error_tally, "errors detected.")
   if error_tally != 0:
     raise FailedTest("%d errors detected" % error_tally)

--- a/ecdsa/rfc6979.py
+++ b/ecdsa/rfc6979.py
@@ -21,11 +21,13 @@ except NameError:
               "4": "0100", "5": "0101", "6": "0110", "7": "0111",
               "8": "1000", "9": "1001", "a": "1010", "b": "1011",
               "c": "1100", "d": "1101", "e": "1110", "f": "1111"}
-    def bin(value): # for python2.5
-        v = "".join(binmap[x] for x in "%x"%abs(value)).lstrip("0")
+
+    def bin(value):  # for python2.5
+        v = "".join(binmap[x] for x in "%x" % abs(value)).lstrip("0")
         if value < 0:
             return "-0b" + v
         return "0b" + v
+
 
 def bit_length(num):
     # http://docs.python.org/dev/library/stdtypes.html#int.bit_length
@@ -33,13 +35,15 @@ def bit_length(num):
     s = s.lstrip('-0b')  # remove leading zeros and minus sign
     return len(s)  # len('100101') --> 6
 
+
 def bits2int(data, qlen):
     x = int(hexlify(data), 16)
     l = len(data) * 8
 
     if l > qlen:
-        return x >> (l-qlen)
+        return x >> (l - qlen)
     return x
+
 
 def bits2octets(data, order):
     z1 = bits2int(data, bit_length(order))
@@ -49,6 +53,7 @@ def bits2octets(data, order):
         z2 = z1
 
     return number_to_string_crop(z2, order)
+
 
 # https://tools.ietf.org/html/rfc6979#section-3.2
 def generate_k(order, secexp, hash_func, data):
@@ -72,13 +77,13 @@ def generate_k(order, secexp, hash_func, data):
 
     # Step D
 
-    k = hmac.new(k, v+b('\x00')+bx, hash_func).digest()
+    k = hmac.new(k, v + b('\x00') + bx, hash_func).digest()
 
     # Step E
     v = hmac.new(k, v, hash_func).digest()
 
     # Step F
-    k = hmac.new(k, v+b('\x01')+bx, hash_func).digest()
+    k = hmac.new(k, v + b('\x01') + bx, hash_func).digest()
 
     # Step G
     v = hmac.new(k, v, hash_func).digest()
@@ -99,5 +104,5 @@ def generate_k(order, secexp, hash_func, data):
         if secret >= 1 and secret < order:
             return secret
 
-        k = hmac.new(k, v+b('\x00'), hash_func).digest()
+        k = hmac.new(k, v + b('\x00'), hash_func).digest()
         v = hmac.new(k, v, hash_func).digest()

--- a/ecdsa/test_pyecdsa.py
+++ b/ecdsa/test_pyecdsa.py
@@ -20,8 +20,10 @@ from .ellipticcurve import Point
 from . import der
 from . import rfc6979
 
+
 class SubprocessError(Exception):
     pass
+
 
 def run_openssl(cmd):
     OPENSSL = "openssl"
@@ -34,7 +36,9 @@ def run_openssl(cmd):
                               (OPENSSL, cmd, p.returncode, stdout))
     return stdout.decode()
 
+
 BENCH = False
+
 
 class ECDSA(unittest.TestCase):
     def test_basic(self):
@@ -45,7 +49,7 @@ class ECDSA(unittest.TestCase):
         sig = priv.sign(data)
 
         self.assertTrue(pub.verify(sig, data))
-        self.assertRaises(BadSignatureError, pub.verify, sig, data+b("bad"))
+        self.assertRaises(BadSignatureError, pub.verify, sig, data + b("bad"))
 
         pub2 = VerifyingKey.from_string(pub.to_string())
         self.assertTrue(pub2.verify(sig, data))
@@ -94,7 +98,7 @@ class ECDSA(unittest.TestCase):
             pub2 = VerifyingKey.from_string(pub1.to_string(), curve)
             self.assertEqual(pub1.to_string(), pub2.to_string())
             self.assertEqual(len(pub1.to_string()),
-                                 curve.verifying_key_length)
+                             curve.verifying_key_length)
             start = time.time()
             sig = priv.sign(b("data"))
             sign_time = time.time() - start
@@ -104,8 +108,8 @@ class ECDSA(unittest.TestCase):
                 pub1.verify(sig, b("data"))
                 verify_time = time.time() - start
                 print_("%s: siglen=%d, keygen=%0.3fs, sign=%0.3f, verify=%0.3f" \
-                      % (curve.name, curve.signature_length,
-                         keygen_time, sign_time, verify_time))
+                       % (curve.name, curve.signature_length,
+                          keygen_time, sign_time, verify_time))
 
     def test_serialize(self):
         seed = b("secret")
@@ -116,7 +120,7 @@ class ECDSA(unittest.TestCase):
         priv1 = SigningKey.from_secret_exponent(secexp1, curve)
         priv2 = SigningKey.from_secret_exponent(secexp2, curve)
         self.assertEqual(hexlify(priv1.to_string()),
-                             hexlify(priv2.to_string()))
+                         hexlify(priv2.to_string()))
         self.assertEqual(priv1.to_pem(), priv2.to_pem())
         pub1 = priv1.get_verifying_key()
         pub2 = priv2.get_verifying_key()
@@ -128,17 +132,19 @@ class ECDSA(unittest.TestCase):
         self.assertTrue(pub1.verify(sig2, data))
         self.assertTrue(pub2.verify(sig2, data))
         self.assertEqual(hexlify(pub1.to_string()),
-                             hexlify(pub2.to_string()))
+                         hexlify(pub2.to_string()))
 
     def test_nonrandom(self):
         s = b("all the entropy in the entire world, compressed into one line")
+
         def not_much_entropy(numbytes):
             return s[:numbytes]
+
         # we control the entropy source, these two keys should be identical:
         priv1 = SigningKey.generate(entropy=not_much_entropy)
         priv2 = SigningKey.generate(entropy=not_much_entropy)
         self.assertEqual(hexlify(priv1.get_verifying_key().to_string()),
-                             hexlify(priv2.get_verifying_key().to_string()))
+                         hexlify(priv2.get_verifying_key().to_string()))
         # likewise, signatures should be identical. Obviously you'd never
         # want to do this with keys you care about, because the secrecy of
         # the private key depends upon using different random numbers for
@@ -149,9 +155,9 @@ class ECDSA(unittest.TestCase):
 
     def assertTruePrivkeysEqual(self, priv1, priv2):
         self.assertEqual(priv1.privkey.secret_multiplier,
-                             priv2.privkey.secret_multiplier)
+                         priv2.privkey.secret_multiplier)
         self.assertEqual(priv1.privkey.public_key.generator,
-                             priv2.privkey.public_key.generator)
+                         priv2.privkey.public_key.generator)
 
     def failIfPrivkeysEqual(self, priv1, priv2):
         self.failIfEqual(priv1.privkey.secret_multiplier,
@@ -159,8 +165,10 @@ class ECDSA(unittest.TestCase):
 
     def test_privkey_creation(self):
         s = b("all the entropy in the entire world, compressed into one line")
+
         def not_much_entropy(numbytes):
             return s[:numbytes]
+
         priv1 = SigningKey.generate()
         self.assertEqual(priv1.baselen, NIST192p.baselen)
 
@@ -242,11 +250,14 @@ class ECDSA(unittest.TestCase):
         self.assertTruePubkeysEqual(pub1, pub2)
 
         self.assertRaises(der.UnexpectedDER,
-                              VerifyingKey.from_der, pub1_der+b("junk"))
+                          VerifyingKey.from_der, pub1_der + b("junk"))
         badpub = VerifyingKey.from_der(pub1_der)
+
         class FakeGenerator:
-            def order(self): return 123456789
-        badcurve = Curve("unknown", None, FakeGenerator(), (1,2,3,4,5,6), None)
+            def order(self):
+                return 123456789
+
+        badcurve = Curve("unknown", None, FakeGenerator(), (1, 2, 3, 4, 5, 6), None)
         badpub.curve = badcurve
         badder = badpub.to_der()
         self.assertRaises(UnknownCurveError, VerifyingKey.from_der, badder)
@@ -322,7 +333,7 @@ class OpenSSL(unittest.TestCase):
         # e.g. "OpenSSL 1.0.0 29 Mar 2010", or "OpenSSL 1.0.0a 1 Jun 2010",
         # or "OpenSSL 0.9.8o 01 Jun 2010"
         vs = v.split()[1].split(".")
-        if vs >= ["1","0","0"]:
+        if vs >= ["1", "0", "0"]:
             return "-SHA1"
         else:
             return "-ecdsa-with-SHA1"
@@ -333,14 +344,19 @@ class OpenSSL(unittest.TestCase):
 
     def test_from_openssl_nist192p(self):
         return self.do_test_from_openssl(NIST192p)
+
     def test_from_openssl_nist224p(self):
         return self.do_test_from_openssl(NIST224p)
+
     def test_from_openssl_nist256p(self):
         return self.do_test_from_openssl(NIST256p)
+
     def test_from_openssl_nist384p(self):
         return self.do_test_from_openssl(NIST384p)
+
     def test_from_openssl_nist521p(self):
         return self.do_test_from_openssl(NIST521p)
+
     def test_from_openssl_secp256k1(self):
         return self.do_test_from_openssl(SECP256k1)
 
@@ -356,30 +372,39 @@ class OpenSSL(unittest.TestCase):
         run_openssl("ecparam -name %s -genkey -out t/privkey.pem" % curvename)
         run_openssl("ec -in t/privkey.pem -pubout -out t/pubkey.pem")
         data = b("data")
-        with open("t/data.txt","wb") as e: e.write(data)
+        with open("t/data.txt", "wb") as e:
+          e.write(data)
         run_openssl("dgst %s -sign t/privkey.pem -out t/data.sig t/data.txt" % mdarg)
         run_openssl("dgst %s -verify t/pubkey.pem -signature t/data.sig t/data.txt" % mdarg)
-        with open("t/pubkey.pem","rb") as e: pubkey_pem = e.read()
-        vk = VerifyingKey.from_pem(pubkey_pem) # 3
-        with open("t/data.sig","rb") as e: sig_der = e.read()
-        self.assertTrue(vk.verify(sig_der, data, # 5
+        with open("t/pubkey.pem", "rb") as e:
+          pubkey_pem = e.read()
+        vk = VerifyingKey.from_pem(pubkey_pem)  # 3
+        with open("t/data.sig", "rb") as e:
+          sig_der = e.read()
+        self.assertTrue(vk.verify(sig_der, data,  # 5
                                   hashfunc=sha1, sigdecode=sigdecode_der))
 
-        with open("t/privkey.pem") as e: fp = e.read()
-        sk = SigningKey.from_pem(fp) # 1
+        with open("t/privkey.pem") as e:
+          fp = e.read()
+        sk = SigningKey.from_pem(fp)  # 1
         sig = sk.sign(data)
         self.assertTrue(vk.verify(sig, data))
 
     def test_to_openssl_nist192p(self):
         self.do_test_to_openssl(NIST192p)
+
     def test_to_openssl_nist224p(self):
         self.do_test_to_openssl(NIST224p)
+
     def test_to_openssl_nist256p(self):
         self.do_test_to_openssl(NIST256p)
+
     def test_to_openssl_nist384p(self):
         self.do_test_to_openssl(NIST384p)
+
     def test_to_openssl_nist521p(self):
         self.do_test_to_openssl(NIST521p)
+
     def test_to_openssl_secp256k1(self):
         self.do_test_to_openssl(SECP256k1)
 
@@ -395,21 +420,28 @@ class OpenSSL(unittest.TestCase):
         sk = SigningKey.generate(curve=curve)
         vk = sk.get_verifying_key()
         data = b("data")
-        with open("t/pubkey.der","wb") as e: e.write(vk.to_der()) # 4
-        with open("t/pubkey.pem","wb") as e: e.write(vk.to_pem()) # 4
+        with open("t/pubkey.der", "wb") as e:
+          e.write(vk.to_der())  # 4
+        with open("t/pubkey.pem", "wb") as e:
+          e.write(vk.to_pem())  # 4
         sig_der = sk.sign(data, hashfunc=sha1, sigencode=sigencode_der)
 
-        with open("t/data.sig","wb") as e: e.write(sig_der) # 6
-        with open("t/data.txt","wb") as e: e.write(data)
-        with open("t/baddata.txt","wb") as e: e.write(data+b("corrupt"))
+        with open("t/data.sig", "wb") as e:
+          e.write(sig_der)  # 6
+        with open("t/data.txt", "wb") as e:
+          e.write(data)
+        with open("t/baddata.txt", "wb") as e:
+          e.write(data + b("corrupt"))
 
         self.assertRaises(SubprocessError, run_openssl,
-                              "dgst %s -verify t/pubkey.der -keyform DER -signature t/data.sig t/baddata.txt" % mdarg)
+                          "dgst %s -verify t/pubkey.der -keyform DER -signature t/data.sig t/baddata.txt" % mdarg)
         run_openssl("dgst %s -verify t/pubkey.der -keyform DER -signature t/data.sig t/data.txt" % mdarg)
 
-        with open("t/privkey.pem","wb") as e: e.write(sk.to_pem()) # 2
+        with open("t/privkey.pem", "wb") as e:
+          e.write(sk.to_pem())  # 2
         run_openssl("dgst %s -sign t/privkey.pem -out t/data.sig2 t/data.txt" % mdarg)
         run_openssl("dgst %s -verify t/pubkey.pem -signature t/data.sig2 t/data.txt" % mdarg)
+
 
 class DER(unittest.TestCase):
     def test_oids(self):
@@ -417,7 +449,7 @@ class DER(unittest.TestCase):
         self.assertEqual(hexlify(oid_ecPublicKey), b("06072a8648ce3d0201"))
         self.assertEqual(hexlify(NIST224p.encoded_oid), b("06052b81040021"))
         self.assertEqual(hexlify(NIST256p.encoded_oid),
-                             b("06082a8648ce3d030107"))
+                         b("06082a8648ce3d030107"))
         x = oid_ecPublicKey + b("more")
         x1, rest = der.remove_object(x)
         self.assertEqual(x1, (1, 2, 840, 10045, 2, 1))
@@ -429,25 +461,26 @@ class DER(unittest.TestCase):
         self.assertEqual(der.encode_integer(127), b("\x02\x01\x7f"))
         self.assertEqual(der.encode_integer(128), b("\x02\x02\x00\x80"))
         self.assertEqual(der.encode_integer(256), b("\x02\x02\x01\x00"))
-        #self.assertEqual(der.encode_integer(-1), b("\x02\x01\xff"))
+        # self.assertEqual(der.encode_integer(-1), b("\x02\x01\xff"))
 
-        def s(n): return der.remove_integer(der.encode_integer(n) + b("junk"))
+        def s(n):
+          return der.remove_integer(der.encode_integer(n) + b("junk"))
         self.assertEqual(s(0), (0, b("junk")))
         self.assertEqual(s(1), (1, b("junk")))
         self.assertEqual(s(127), (127, b("junk")))
         self.assertEqual(s(128), (128, b("junk")))
         self.assertEqual(s(256), (256, b("junk")))
         self.assertEqual(s(1234567890123456789012345678901234567890),
-                             (1234567890123456789012345678901234567890,b("junk")))
+                         (1234567890123456789012345678901234567890, b("junk")))
 
     def test_number(self):
         self.assertEqual(der.encode_number(0), b("\x00"))
         self.assertEqual(der.encode_number(127), b("\x7f"))
         self.assertEqual(der.encode_number(128), b("\x81\x00"))
-        self.assertEqual(der.encode_number(3*128+7), b("\x83\x07"))
-        #self.assertEqual(der.read_number("\x81\x9b"+"more"), (155, 2))
-        #self.assertEqual(der.encode_number(155), b("\x81\x9b"))
-        for n in (0, 1, 2, 127, 128, 3*128+7, 840, 10045): #, 155):
+        self.assertEqual(der.encode_number(3 * 128 + 7), b("\x83\x07"))
+        # self.assertEqual(der.read_number("\x81\x9b" + "more"), (155, 2))
+        # self.assertEqual(der.encode_number(155), b("\x81\x9b"))
+        for n in (0, 1, 2, 127, 128, 3 * 128 + 7, 840, 10045):  # , 155):
             x = der.encode_number(n) + b("more")
             n1, llen = der.read_number(x)
             self.assertEqual(n1, n)
@@ -459,10 +492,10 @@ class DER(unittest.TestCase):
         self.assertEqual(der.encode_length(128), b("\x81\x80"))
         self.assertEqual(der.encode_length(255), b("\x81\xff"))
         self.assertEqual(der.encode_length(256), b("\x82\x01\x00"))
-        self.assertEqual(der.encode_length(3*256+7), b("\x82\x03\x07"))
-        self.assertEqual(der.read_length(b("\x81\x9b")+b("more")), (155, 2))
+        self.assertEqual(der.encode_length(3 * 256 + 7), b("\x82\x03\x07"))
+        self.assertEqual(der.read_length(b("\x81\x9b") + b("more")), (155, 2))
         self.assertEqual(der.encode_length(155), b("\x81\x9b"))
-        for n in (0, 1, 2, 127, 128, 255, 256, 3*256+7, 155):
+        for n in (0, 1, 2, 127, 128, 255, 256, 3 * 256 + 7, 155):
             x = der.encode_length(n) + b("more")
             n1, llen = der.read_length(x)
             self.assertEqual(n1, n)
@@ -481,33 +514,34 @@ class DER(unittest.TestCase):
         x = der.encode_constructed(1, unhexlify(b("0102030a0b0c")))
         self.assertEqual(hexlify(x), b("a106") + b("0102030a0b0c"))
 
+
 class Util(unittest.TestCase):
     def test_trytryagain(self):
         tta = util.randrange_from_seed__trytryagain
         for i in range(1000):
             seed = "seed-%d" % i
-            for order in (2**8-2, 2**8-1, 2**8, 2**8+1, 2**8+2,
-                          2**16-1, 2**16+1):
+            for order in (2**8 - 2, 2**8 - 1, 2**8, 2**8 + 1, 2**8 + 2,
+                          2**16 - 1, 2**16 + 1):
                 n = tta(seed, order)
                 self.assertTrue(1 <= n < order, (1, n, order))
         # this trytryagain *does* provide long-term stability
-        self.assertEqual(("%x"%(tta("seed", NIST224p.order))).encode(),
-                             b("6fa59d73bf0446ae8743cf748fc5ac11d5585a90356417e97155c3bc"))
+        self.assertEqual(("%x" % (tta("seed", NIST224p.order))).encode(),
+                         b("6fa59d73bf0446ae8743cf748fc5ac11d5585a90356417e97155c3bc"))
 
     def test_randrange(self):
         # util.randrange does not provide long-term stability: we might
         # change the algorithm in the future.
         for i in range(1000):
             entropy = util.PRNG("seed-%d" % i)
-            for order in (2**8-2, 2**8-1, 2**8,
-                          2**16-1, 2**16+1,
+            for order in (2**8 - 2, 2**8 - 1, 2**8,
+                          2**16 - 1, 2**16 + 1,
                           ):
                 # that oddball 2**16+1 takes half our runtime
                 n = util.randrange(order, entropy=entropy)
                 self.assertTrue(1 <= n < order, (1, n, order))
 
     def OFF_test_prove_uniformity(self):
-        order = 2**8-2
+        order = 2**8 - 2
         counts = dict([(i, 0) for i in range(1, order)])
         assert 0 not in counts
         assert order not in counts
@@ -516,9 +550,10 @@ class Util(unittest.TestCase):
             n = util.randrange_from_seed__trytryagain(seed, order)
             counts[n] += 1
         # this technique should use the full range
-        self.assertTrue(counts[order-1])
+        self.assertTrue(counts[order - 1])
         for i in range(1, order):
-            print_("%3d: %s" % (i, "*"*(counts[i]//100)))
+            print_("%3d: %s" % (i, "*" * (counts[i] // 100)))
+
 
 class RFC6979(unittest.TestCase):
     # https://tools.ietf.org/html/rfc6979#appendix-A.1
@@ -530,11 +565,11 @@ class RFC6979(unittest.TestCase):
         '''RFC doesn't contain test vectors for SECP256k1 used in bitcoin.
         This vector has been computed by Golang reference implementation instead.'''
         self._do(
-            generator = SECP256k1.generator,
-            secexp = int("9d0219792467d7d37b4d43298a7d0c05", 16),
-            hsh = sha256(b("sample")).digest(),
-            hash_func = sha256,
-            expected = int("8fa1f95d514760e498f28957b824ee6ec39ed64826ff4fecc2b5739ec45b91cd", 16))
+            generator=SECP256k1.generator,
+            secexp=int("9d0219792467d7d37b4d43298a7d0c05", 16),
+            hsh=sha256(b("sample")).digest(),
+            hash_func=sha256,
+            expected=int("8fa1f95d514760e498f28957b824ee6ec39ed64826ff4fecc2b5739ec45b91cd", 16))
 
     def test_SECP256k1_2(self):
         self._do(
@@ -579,85 +614,88 @@ class RFC6979(unittest.TestCase):
     def test_1(self):
         # Basic example of the RFC, it also tests 'try-try-again' from Step H of rfc6979
         self._do(
-            generator = Point(None, 0, 0, int("4000000000000000000020108A2E0CC0D99F8A5EF", 16)),
-            secexp = int("09A4D6792295A7F730FC3F2B49CBC0F62E862272F", 16),
-            hsh = unhexlify(b("AF2BDBE1AA9B6EC1E2ADE1D694F41FC71A831D0268E9891562113D8A62ADD1BF")),
-            hash_func = sha256,
-            expected = int("23AF4074C90A02B3FE61D286D5C87F425E6BDD81B", 16))
+            generator=Point(None, 0, 0, int("4000000000000000000020108A2E0CC0D99F8A5EF", 16)),
+            secexp=int("09A4D6792295A7F730FC3F2B49CBC0F62E862272F", 16),
+            hsh=unhexlify(b("AF2BDBE1AA9B6EC1E2ADE1D694F41FC71A831D0268E9891562113D8A62ADD1BF")),
+            hash_func=sha256,
+            expected=int("23AF4074C90A02B3FE61D286D5C87F425E6BDD81B", 16))
 
     def test_2(self):
         self._do(
             generator=NIST192p.generator,
-            secexp = int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
-            hsh = sha1(b("sample")).digest(),
-            hash_func = sha1,
-            expected = int("37D7CA00D2C7B0E5E412AC03BD44BA837FDD5B28CD3B0021", 16))
+            secexp=int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
+            hsh=sha1(b("sample")).digest(),
+            hash_func=sha1,
+            expected=int("37D7CA00D2C7B0E5E412AC03BD44BA837FDD5B28CD3B0021", 16))
 
     def test_3(self):
         self._do(
             generator=NIST192p.generator,
-            secexp = int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
-            hsh = sha256(b("sample")).digest(),
-            hash_func = sha256,
-            expected = int("32B1B6D7D42A05CB449065727A84804FB1A3E34D8F261496", 16))
+            secexp=int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
+            hsh=sha256(b("sample")).digest(),
+            hash_func=sha256,
+            expected=int("32B1B6D7D42A05CB449065727A84804FB1A3E34D8F261496", 16))
 
     def test_4(self):
         self._do(
             generator=NIST192p.generator,
-            secexp = int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
-            hsh = sha512(b("sample")).digest(),
-            hash_func = sha512,
-            expected = int("A2AC7AB055E4F20692D49209544C203A7D1F2C0BFBC75DB1", 16))
+            secexp=int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
+            hsh=sha512(b("sample")).digest(),
+            hash_func=sha512,
+            expected=int("A2AC7AB055E4F20692D49209544C203A7D1F2C0BFBC75DB1", 16))
 
     def test_5(self):
         self._do(
             generator=NIST192p.generator,
-            secexp = int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
-            hsh = sha1(b("test")).digest(),
-            hash_func = sha1,
-            expected = int("D9CF9C3D3297D3260773A1DA7418DB5537AB8DD93DE7FA25", 16))
+            secexp=int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
+            hsh=sha1(b("test")).digest(),
+            hash_func=sha1,
+            expected=int("D9CF9C3D3297D3260773A1DA7418DB5537AB8DD93DE7FA25", 16))
 
     def test_6(self):
         self._do(
             generator=NIST192p.generator,
-            secexp = int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
-            hsh = sha256(b("test")).digest(),
-            hash_func = sha256,
-            expected = int("5C4CE89CF56D9E7C77C8585339B006B97B5F0680B4306C6C", 16))
+            secexp=int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
+            hsh=sha256(b("test")).digest(),
+            hash_func=sha256,
+            expected=int("5C4CE89CF56D9E7C77C8585339B006B97B5F0680B4306C6C", 16))
 
     def test_7(self):
         self._do(
             generator=NIST192p.generator,
-            secexp = int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
-            hsh = sha512(b("test")).digest(),
-            hash_func = sha512,
-            expected = int("0758753A5254759C7CFBAD2E2D9B0792EEE44136C9480527", 16))
+            secexp=int("6FAB034934E4C0FC9AE67F5B5659A9D7D1FEFD187EE09FD4", 16),
+            hsh=sha512(b("test")).digest(),
+            hash_func=sha512,
+            expected=int("0758753A5254759C7CFBAD2E2D9B0792EEE44136C9480527", 16))
 
     def test_8(self):
         self._do(
             generator=NIST521p.generator,
-            secexp = int("0FAD06DAA62BA3B25D2FB40133DA757205DE67F5BB0018FEE8C86E1B68C7E75CAA896EB32F1F47C70855836A6D16FCC1466F6D8FBEC67DB89EC0C08B0E996B83538", 16),
-            hsh = sha1(b("sample")).digest(),
-            hash_func = sha1,
-            expected = int("089C071B419E1C2820962321787258469511958E80582E95D8378E0C2CCDB3CB42BEDE42F50E3FA3C71F5A76724281D31D9C89F0F91FC1BE4918DB1C03A5838D0F9", 16))
+            secexp=int("0FAD06DAA62BA3B25D2FB40133DA757205DE67F5BB0018FEE8C86E1B68C7E75CAA896EB32F1F47C70855836A6D16FCC1466F6D8FBEC67DB89EC0C08B0E996B83538", 16),
+            hsh=sha1(b("sample")).digest(),
+            hash_func=sha1,
+            expected=int("089C071B419E1C2820962321787258469511958E80582E95D8378E0C2CCDB3CB42BEDE42F50E3FA3C71F5A76724281D31D9C89F0F91FC1BE4918DB1C03A5838D0F9", 16))
 
     def test_9(self):
         self._do(
             generator=NIST521p.generator,
-            secexp = int("0FAD06DAA62BA3B25D2FB40133DA757205DE67F5BB0018FEE8C86E1B68C7E75CAA896EB32F1F47C70855836A6D16FCC1466F6D8FBEC67DB89EC0C08B0E996B83538", 16),
-            hsh = sha256(b("sample")).digest(),
-            hash_func = sha256,
-            expected = int("0EDF38AFCAAECAB4383358B34D67C9F2216C8382AAEA44A3DAD5FDC9C32575761793FEF24EB0FC276DFC4F6E3EC476752F043CF01415387470BCBD8678ED2C7E1A0", 16))
+            secexp=int("0FAD06DAA62BA3B25D2FB40133DA757205DE67F5BB0018FEE8C86E1B68C7E75CAA896EB32F1F47C70855836A6D16FCC1466F6D8FBEC67DB89EC0C08B0E996B83538", 16),
+            hsh=sha256(b("sample")).digest(),
+            hash_func=sha256,
+            expected=int("0EDF38AFCAAECAB4383358B34D67C9F2216C8382AAEA44A3DAD5FDC9C32575761793FEF24EB0FC276DFC4F6E3EC476752F043CF01415387470BCBD8678ED2C7E1A0", 16))
 
     def test_10(self):
         self._do(
             generator=NIST521p.generator,
-            secexp = int("0FAD06DAA62BA3B25D2FB40133DA757205DE67F5BB0018FEE8C86E1B68C7E75CAA896EB32F1F47C70855836A6D16FCC1466F6D8FBEC67DB89EC0C08B0E996B83538", 16),
-            hsh = sha512(b("test")).digest(),
-            hash_func = sha512,
-            expected = int("16200813020EC986863BEDFC1B121F605C1215645018AEA1A7B215A564DE9EB1B38A67AA1128B80CE391C4FB71187654AAA3431027BFC7F395766CA988C964DC56D", 16))
+            secexp=int("0FAD06DAA62BA3B25D2FB40133DA757205DE67F5BB0018FEE8C86E1B68C7E75CAA896EB32F1F47C70855836A6D16FCC1466F6D8FBEC67DB89EC0C08B0E996B83538", 16),
+            hsh=sha512(b("test")).digest(),
+            hash_func=sha512,
+            expected=int("16200813020EC986863BEDFC1B121F605C1215645018AEA1A7B215A564DE9EB1B38A67AA1128B80CE391C4FB71187654AAA3431027BFC7F395766CA988C964DC56D", 16))
+
 
 def __main__():
     unittest.main()
+
+
 if __name__ == "__main__":
     __main__()

--- a/ecdsa/util.py
+++ b/ecdsa/util.py
@@ -16,6 +16,7 @@ from .six import PY3, int2byte, b, next
 oid_ecPublicKey = (1, 2, 840, 10045, 2, 1)
 encoded_oid_ecPublicKey = der.encode_oid(*oid_ecPublicKey)
 
+
 def randrange(order, entropy=None):
     """Return a random integer k such that 1 <= k < order, uniformly
     distributed across that range. For simplicity, this only behaves well if
@@ -45,7 +46,7 @@ def randrange(order, entropy=None):
         entropy = os.urandom
     assert order > 1
     bytes = orderlen(order)
-    dont_try_forever = 10000 # gives about 2**-60 failures for worst case
+    dont_try_forever = 10000  # gives about 2**-60 failures for worst case
     while dont_try_forever > 0:
         dont_try_forever -= 1
         candidate = string_to_number(entropy(bytes)) + 1
@@ -55,6 +56,7 @@ def randrange(order, entropy=None):
     raise RuntimeError("randrange() tried hard but gave up, either something"
                        " is very wrong or you got realllly unlucky. Order was"
                        " %x" % order)
+
 
 class PRNG:
     # this returns a callable which, when invoked with an integer N, will
@@ -73,13 +75,13 @@ class PRNG:
         else:
             return "".join(a)
 
-
     def block_generator(self, seed):
         counter = 0
         while True:
             for byte in sha256(("prng-%d-%s" % (counter, seed)).encode()).digest():
                 yield byte
             counter += 1
+
 
 def randrange_from_seed__overshoot_modulo(seed, order):
     # hash the data, then turn the digest into a number in [1,order).
@@ -88,18 +90,22 @@ def randrange_from_seed__overshoot_modulo(seed, order):
     # sufficiently larger than the group order, then modulo it down to fit.
     # This should give adequate (but not perfect) uniformity, and simple
     # code. There are other choices: try-try-again is the main one.
-    base = PRNG(seed)(2*orderlen(order))
-    number = (int(binascii.hexlify(base), 16) % (order-1)) + 1
+    base = PRNG(seed)(2 * orderlen(order))
+    number = (int(binascii.hexlify(base), 16) % (order - 1)) + 1
     assert 1 <= number < order, (1, number, order)
     return number
 
+
 def lsb_of_ones(numbits):
     return (1 << numbits) - 1
+
+
 def bits_and_bytes(order):
-    bits = int(math.log(order-1, 2)+1)
+    bits = int(math.log(order - 1, 2) + 1)
     bytes = bits // 8
     extrabits = bits % 8
     return bits, bytes, extrabits
+
 
 # the following randrange_from_seed__METHOD() functions take an
 # arbitrarily-sized secret seed and turn it into a number that obeys the same
@@ -116,28 +122,30 @@ def randrange_from_seed__truncate_bytes(seed, order, hashmod=sha256):
     # hash the seed, then turn the digest into a number in [1,order), but
     # don't worry about trying to uniformly fill the range. This will lose,
     # on average, four bits of entropy.
-    bits, bytes, extrabits = bits_and_bytes(order)
+    bits, _bytes, extrabits = bits_and_bytes(order)
     if extrabits:
         bytes += 1
-    base = hashmod(seed).digest()[:bytes]
-    base = "\x00"*(bytes-len(base)) + base
-    number = 1+int(binascii.hexlify(base), 16)
+    base = hashmod(seed).digest()[:_bytes]
+    base = "\x00" * (_bytes - len(base)) + base
+    number = 1 + int(binascii.hexlify(base), 16)
     assert 1 <= number < order
     return number
+
 
 def randrange_from_seed__truncate_bits(seed, order, hashmod=sha256):
     # like string_to_randrange_truncate_bytes, but only lose an average of
     # half a bit
-    bits = int(math.log(order-1, 2)+1)
-    maxbytes = (bits+7) // 8
+    bits = int(math.log(order - 1, 2) + 1)
+    maxbytes = (bits + 7) // 8
     base = hashmod(seed).digest()[:maxbytes]
-    base = "\x00"*(maxbytes-len(base)) + base
-    topbits = 8*maxbytes - bits
+    base = "\x00" * (maxbytes - len(base)) + base
+    topbits = 8 * maxbytes - bits
     if topbits:
         base = int2byte(ord(base[0]) & lsb_of_ones(topbits)) + base[1:]
-    number = 1+int(binascii.hexlify(base), 16)
+    number = 1 + int(binascii.hexlify(base), 16)
     assert 1 <= number < order
     return number
+
 
 def randrange_from_seed__trytryagain(seed, order):
     # figure out exactly how many bits we need (rounded up to the nearest
@@ -160,24 +168,28 @@ def randrange_from_seed__trytryagain(seed, order):
 
 def number_to_string(num, order):
     l = orderlen(order)
-    fmt_str = "%0" + str(2*l) + "x"
+    fmt_str = "%0" + str(2 * l) + "x"
     string = binascii.unhexlify((fmt_str % num).encode())
     assert len(string) == l, (len(string), l)
     return string
 
+
 def number_to_string_crop(num, order):
     l = orderlen(order)
-    fmt_str = "%0" + str(2*l) + "x"
+    fmt_str = "%0" + str(2 * l) + "x"
     string = binascii.unhexlify((fmt_str % num).encode())
     return string[:l]
 
+
 def string_to_number(string):
     return int(binascii.hexlify(string), 16)
+
 
 def string_to_number_fixedlen(string, order):
     l = orderlen(order)
     assert len(string) == l, (len(string), l)
     return int(binascii.hexlify(string), 16)
+
 
 # these methods are useful for the sigencode= argument to SK.sign() and the
 # sigdecode= argument to VK.verify(), and control how the signature is packed
@@ -188,14 +200,17 @@ def sigencode_strings(r, s, order):
     s_str = number_to_string(s, order)
     return (r_str, s_str)
 
+
 def sigencode_string(r, s, order):
     # for any given curve, the size of the signature numbers is
     # fixed, so just use simple concatenation
     r_str, s_str = sigencode_strings(r, s, order)
     return r_str + s_str
 
+
 def sigencode_der(r, s, order):
     return der.encode_sequence(der.encode_integer(r), der.encode_integer(s))
+
 
 # canonical versions of sigencode methods
 # these enforce low S values, by negating the value (modulo the order) if above order/2
@@ -205,10 +220,12 @@ def sigencode_strings_canonize(r, s, order):
         s = order - s
     return sigencode_strings(r, s, order)
 
+
 def sigencode_string_canonize(r, s, order):
     if s > order / 2:
         s = order - s
     return sigencode_string(r, s, order)
+
 
 def sigencode_der_canonize(r, s, order):
     if s > order / 2:
@@ -218,10 +235,11 @@ def sigencode_der_canonize(r, s, order):
 
 def sigdecode_string(signature, order):
     l = orderlen(order)
-    assert len(signature) == 2*l, (len(signature), 2*l)
+    assert len(signature) == 2 * l, (len(signature), 2 * l)
     r = string_to_number_fixedlen(signature[:l], order)
     s = string_to_number_fixedlen(signature[l:], order)
     return r, s
+
 
 def sigdecode_strings(rs_strings, order):
     (r_str, s_str) = rs_strings
@@ -232,8 +250,9 @@ def sigdecode_strings(rs_strings, order):
     s = string_to_number_fixedlen(s_str, order)
     return r, s
 
+
 def sigdecode_der(sig_der, order):
-    #return der.encode_sequence(der.encode_integer(r), der.encode_integer(s))
+    # return der.encode_sequence(der.encode_integer(r), der.encode_integer(s))
     rs_strings, empty = der.remove_sequence(sig_der)
     if empty != b(""):
         raise der.UnexpectedDER("trailing junk after DER sig: %s" %
@@ -244,4 +263,3 @@ def sigdecode_der(sig_der, order):
         raise der.UnexpectedDER("trailing junk after DER numbers: %s" %
                                 binascii.hexlify(empty))
     return r, s
-


### PR DESCRIPTION
Used the `pep8` tool, with `--ignore=E111,E114,E501,E121,E502` to make the code base more PEP8 compliant. This change should only be about whitespace and in the case of `__init__.py`.also some ordering of the code (to comply with PEP8 guidelines).

This doesn't address `_version.py` and `six.py` as I assume these to be external.