### PR TITLE
Coverage fix

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,11 @@
 
 [run]
 include =
- ecdsa/*
+ src/ecdsa/*
 omit =
- ecdsa/six.py
- ecdsa/_version.py
- ecdsa/test_ecdsa.py
+ src/ecdsa/six.py
+ src/ecdsa/_version.py
+ src/ecdsa/test_ecdsa.py
+ src/ecdsa/test_ellipticcurve.py
+ src/ecdsa/test_numbertheory.py
+ src/ecdsa/test_pyecdsa.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
   - "pypy"
   - "pypy3"
 install:
-  - pip install -U tox python-coveralls
+  - travis_retry pip install -U tox python-coveralls
 script:
   - tox -e coverage
   - tox -e speed

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,34 @@ language: python
 cache: pip
 before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "pypy"
-  - "pypy3"
+matrix:
+  include:
+      - python: 2.6
+        env: TOX_ENV=py26
+      - python: 2.7
+        env: TOX_ENV=py27
+      - python: 3.3
+        env: TOX_ENV=py33
+      - python: 3.4
+        env: TOX_ENV=py34
+      - python: 3.5
+        env: TOX_ENV=py35
+      - python: 3.6
+        env: TOX_ENV=py36
+      - python: pypy
+        env: TOX_ENV=pypy
+      - python: pypy3
+        env: TOX_ENV=pypy3
+  allow_failures:
+    - python: "pypy3"
+
 install:
-  - travis_retry pip install -U tox python-coveralls
+  - pip list
+  - if [[ -e build-requirements-${TRAVIS_PYTHON_VERSION}.txt ]]; then travis_retry pip install -r build-requirements-${TRAVIS_PYTHON_VERSION}.txt; else travis_retry pip install -r build-requirements.txt; fi
+  - pip list
 script:
-  - tox -e coverage
+  - tox -e $TOX_ENV
   - tox -e speed
 after_success:
   - coveralls
 
-matrix:
-  allow_failures:
-    - python: "pypy3"

--- a/build-requirements-3.3.txt
+++ b/build-requirements-3.3.txt
@@ -1,0 +1,4 @@
+python-coveralls
+tox<3.0
+wheel<0.30
+virtualenv==15.2.0

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,2 @@
+tox
+python-coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,18 @@
 
 [tox]
-envlist = py26, py27, py33, py34, py35, py36
+envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3
 
 [testenv]
 deps =
-     pytest
-commands = py.test {posargs:src/ecdsa}
+     py{33}: py<1.5
+     py{33}: pytest<3.3
+     py{26,27,34,35,36,py,py3}: pytest
+     py{33}: wheel<0.30
+     coverage
+commands = coverage run --branch -m pytest {posargs:src/ecdsa}
 
 [testenv:coverage]
-deps =
-     coverage
-     pytest
+sitepackages=True
 commands = coverage run --branch -m pytest {posargs:src/ecdsa}
 
 [testenv:speed]
@@ -23,7 +25,6 @@ deps =
      flake8
 commands =
          flake8 setup.py speed.py src
-
 
 [flake8]
 exclude = src/ecdsa/test*.py

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = py.test {posargs:src/ecdsa}
 deps =
      coverage
      pytest
-commands = coverage run -m pytest {posargs:src/ecdsa}
+commands = coverage run --branch -m pytest {posargs:src/ecdsa}
 
 [testenv:speed]
 commands = {envpython} speed.py


### PR DESCRIPTION
because the code moved to `src` directory, the old `coverage` includes/excludes became obsoleted, fix this

also include branch coverage in collection

fixes #83 