### PR TITLE
Specify markdown README for PyPI's long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python
 
+import io
+import os
+
 from setuptools import setup
 import versioneer
 
 commands = versioneer.get_cmdclass().copy()
 
+# Use README.md to set markdown long_description
+directory = os.path.abspath(os.path.dirname(__file__))
+readme_path = os.path.join(directory, "README.md")
+with io.open(readme_path, encoding="utf-8") as read_file:
+    long_description = read_file.read()
+
 setup(name="ecdsa",
       version=versioneer.get_version(),
       description="ECDSA cryptographic signature library (pure python)",
+      long_description=long_description,
       long_description_content_type='text/markdown',
       author="Brian Warner",
       author_email="warner@lothar.com",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ commands = versioneer.get_cmdclass().copy()
 setup(name="ecdsa",
       version=versioneer.get_version(),
       description="ECDSA cryptographic signature library (pure python)",
+      long_description_content_type='text/markdown',
       author="Brian Warner",
       author_email="warner@lothar.com",
       url="http://github.com/warner/python-ecdsa",


### PR DESCRIPTION
Set `long_description_content_type='text/markdown'` in `setup.py`. I believe this should trigger the README to display with proper formatting on [PyPI](https://pypi.org/project/ecdsa/). Currently, PyPI looks like:

![pypi-ecdsa](https://user-images.githubusercontent.com/1117703/39214782-a2ae4392-47e3-11e8-82f4-a85037a57fcb.png)

Refs https://packaging.python.org/tutorials/distributing-packages/#description and https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi.