### PR TITLE
Add ability to include additional data as per RFC6979 section 3.6

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -225,13 +225,13 @@ class SigningKey:
     def get_verifying_key(self):
         return self.verifying_key
 
-    def sign_deterministic(self, data, hashfunc=None, sigencode=sigencode_string):
+    def sign_deterministic(self, data, hashfunc=None, sigencode=sigencode_string, extra_entropy=b('')):
         hashfunc = hashfunc or self.default_hashfunc
         digest = hashfunc(data).digest()
 
-        return self.sign_digest_deterministic(digest, hashfunc=hashfunc, sigencode=sigencode)
+        return self.sign_digest_deterministic(digest, hashfunc=hashfunc, sigencode=sigencode, extra_entropy=extra_entropy)
 
-    def sign_digest_deterministic(self, digest, hashfunc=None, sigencode=sigencode_string):
+    def sign_digest_deterministic(self, digest, hashfunc=None, sigencode=sigencode_string, extra_entropy=b('')):
         """
         Calculates 'k' from data itself, removing the need for strong
         random generator and producing deterministic (reproducible) signatures.
@@ -239,7 +239,7 @@ class SigningKey:
         """
         secexp = self.privkey.secret_multiplier
         k = rfc6979.generate_k(
-            self.curve.generator.order(), secexp, hashfunc, digest)
+            self.curve.generator.order(), secexp, hashfunc, digest, extra_entropy=extra_entropy)
 
         return self.sign_digest(digest, sigencode=sigencode, k=k)
 

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -225,13 +225,13 @@ class SigningKey:
     def get_verifying_key(self):
         return self.verifying_key
 
-    def sign_deterministic(self, data, hashfunc=None, sigencode=sigencode_string, extra_entropy=b('')):
+    def sign_deterministic(self, data, hashfunc=None, sigencode=sigencode_string, extra_entropy=b''):
         hashfunc = hashfunc or self.default_hashfunc
         digest = hashfunc(data).digest()
 
         return self.sign_digest_deterministic(digest, hashfunc=hashfunc, sigencode=sigencode, extra_entropy=extra_entropy)
 
-    def sign_digest_deterministic(self, digest, hashfunc=None, sigencode=sigencode_string, extra_entropy=b('')):
+    def sign_digest_deterministic(self, digest, hashfunc=None, sigencode=sigencode_string, extra_entropy=b''):
         """
         Calculates 'k' from data itself, removing the need for strong
         random generator and producing deterministic (reproducible) signatures.

--- a/src/ecdsa/rfc6979.py
+++ b/src/ecdsa/rfc6979.py
@@ -56,7 +56,7 @@ def bits2octets(data, order):
 
 
 # https://tools.ietf.org/html/rfc6979#section-3.2
-def generate_k(order, secexp, hash_func, data):
+def generate_k(order, secexp, hash_func, data, extra_entropy=b('')):
     '''
         order - order of the DSA generator used in the signature
         secexp - secure exponent (private key) in numeric form
@@ -67,7 +67,7 @@ def generate_k(order, secexp, hash_func, data):
     qlen = bit_length(order)
     holen = hash_func().digest_size
     rolen = (qlen + 7) / 8
-    bx = number_to_string(secexp, order) + bits2octets(data, order)
+    bx = number_to_string(secexp, order) + bits2octets(data, order) + extra_entropy
 
     # Step B
     v = b('\x01') * holen

--- a/src/ecdsa/rfc6979.py
+++ b/src/ecdsa/rfc6979.py
@@ -56,12 +56,13 @@ def bits2octets(data, order):
 
 
 # https://tools.ietf.org/html/rfc6979#section-3.2
-def generate_k(order, secexp, hash_func, data, extra_entropy=b('')):
+def generate_k(order, secexp, hash_func, data, extra_entropy=b''):
     '''
         order - order of the DSA generator used in the signature
         secexp - secure exponent (private key) in numeric form
         hash_func - reference to the same hash function used for generating hash
         data - hash in binary form of the signing data
+        extra_entropy - extra added data in binary form as per section-3.6 of rfc6979
     '''
 
     qlen = bit_length(order)


### PR DESCRIPTION
```
  Additional data may be added to the input of HMAC, concatenated
  after bits2octets(H(m)):
    K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1) || k')
```

Also follows implementation in secp256k1 library:
https://github.com/bitcoin-core/secp256k1/blob/452d8e4d2a2f9f1b5be6b02e18f1ba102e5ca0b4/src/secp256k1.c#L332

Recently, Bitcoin Core merged a feature that utilizes this feature in the secp256k1 library.

Eventually, Electrum (which depends on this library) may implement it, so would like to lay the ground work.