### PR TITLE
Make sure that r and s don't become 0

### DIFF
--- a/src/ecdsa/ecdsa.py
+++ b/src/ecdsa/ecdsa.py
@@ -140,7 +140,7 @@ class Private_key(object):
     n = G.order()
     k = random_k % n
     p1 = k * G
-    r = p1.x()
+    r = p1.x() % n
     if r == 0:
       raise RuntimeError("amazingly unlucky random number r")
     s = (numbertheory.inverse_mod(k, n) *
@@ -274,4 +274,3 @@ _r = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
 
 curve_secp256k1 = ellipticcurve.CurveFp(_p, _a, _b)
 generator_secp256k1 = ellipticcurve.Point(curve_secp256k1, _Gx, _Gy, _r)
-

--- a/src/ecdsa/ecdsa.py
+++ b/src/ecdsa/ecdsa.py
@@ -58,6 +58,10 @@ from . import ellipticcurve
 from . import numbertheory
 
 
+class RSZeroError(RuntimeError):
+    pass
+
+
 class Signature(object):
   """ECDSA signature.
   """
@@ -142,11 +146,11 @@ class Private_key(object):
     p1 = k * G
     r = p1.x() % n
     if r == 0:
-      raise RuntimeError("amazingly unlucky random number r")
+      raise RSZeroError("amazingly unlucky random number r")
     s = (numbertheory.inverse_mod(k, n) *
          (hash + (self.secret_multiplier * r) % n)) % n
     if s == 0:
-      raise RuntimeError("amazingly unlucky random number s")
+      raise RSZeroError("amazingly unlucky random number s")
     return Signature(r, s)
 
 

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -1,9 +1,10 @@
-import binascii, re
+import binascii
 
 from . import ecdsa
 from . import der
 from . import rfc6979
 from .curves import NIST192p, find_curve
+from .ecdsa import RSZeroError
 from .util import string_to_number, number_to_string, randrange
 from .util import sigencode_string, sigdecode_string
 from .util import oid_ecPublicKey, encoded_oid_ecPublicKey
@@ -249,11 +250,8 @@ class SigningKey:
             try:
                 r, s, order = self.sign_digest(digest, sigencode=simple_r_s, k=k)
                 break
-            except RuntimeError as e:
-                if re.match("^amazingly unlucky random number (r|s)$", str(e)):
-                    retry_gen += 1
-                else:
-                    raise e
+            except RSZeroError:
+                retry_gen += 1
 
         return sigencode(r, s, order)
 

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -240,14 +240,14 @@ class SigningKey:
         secexp = self.privkey.secret_multiplier
 
         def simple_r_s(r, s, order):
-            return r, s, order
+            return r, s
 
         retry_gen = 0
         while True:
             k = rfc6979.generate_k(
                 self.curve.generator.order(), secexp, hashfunc, digest, retry_gen=retry_gen)
-            r, s, order = self.sign_digest(digest, sigencode=simple_r_s, k=k)
-            if r % order != 0 and s % order != 0:
+            r, s = self.sign_digest(digest, sigencode=simple_r_s, k=k)
+            if r != 0 and s != 0:
                 break
             retry_gen += 1
 

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -238,10 +238,20 @@ class SigningKey:
         See RFC 6979 for more details.
         """
         secexp = self.privkey.secret_multiplier
-        k = rfc6979.generate_k(
-            self.curve.generator.order(), secexp, hashfunc, digest)
 
-        return self.sign_digest(digest, sigencode=sigencode, k=k)
+        def simple_r_s(r, s, order):
+            return r, s, order
+
+        retry_gen = 0
+        while True:
+            k = rfc6979.generate_k(
+                self.curve.generator.order(), secexp, hashfunc, digest, retry_gen=retry_gen)
+            r, s, order = self.sign_digest(digest, sigencode=simple_r_s, k=k)
+            if r % order != 0 and s % order != 0:
+                break
+            retry_gen += 1
+
+        return sigencode(r, s, order)
 
     def sign(self, data, entropy=None, hashfunc=None, sigencode=sigencode_string, k=None):
         """

--- a/src/ecdsa/rfc6979.py
+++ b/src/ecdsa/rfc6979.py
@@ -56,12 +56,13 @@ def bits2octets(data, order):
 
 
 # https://tools.ietf.org/html/rfc6979#section-3.2
-def generate_k(order, secexp, hash_func, data):
+def generate_k(order, secexp, hash_func, data, retry_gen=0):
     '''
         order - order of the DSA generator used in the signature
         secexp - secure exponent (private key) in numeric form
         hash_func - reference to the same hash function used for generating hash
         data - hash in binary form of the signing data
+        retry_gen - int - how many good 'k' values to skip before returning
     '''
 
     qlen = bit_length(order)
@@ -102,7 +103,10 @@ def generate_k(order, secexp, hash_func, data):
         secret = bits2int(t, qlen)
 
         if secret >= 1 and secret < order:
-            return secret
+            if retry_gen <= 0:
+                return secret
+            else:
+                retry_gen -= 1
 
         k = hmac.new(k, v + b('\x00'), hash_func).digest()
         v = hmac.new(k, v, hash_func).digest()


### PR DESCRIPTION
As per rfc6979:

> If that value of k is within the [1,q-1] range, **and is**
> **suitable for DSA or ECDSA (i.e., it results in an r value**
> **that is not 0; see Section 3.4)**, then the generation of k is
> finished. The obtained value of k is used in DSA or ECDSA.
> Otherwise, compute:

` k is within the [1,q-1] range` is being checked, but the part about r and s values aren't 0 is not currently being checked.

In the event a sig with 0 as the r or s value is leaked, the private key is easily calculated.

(Though this is extremely rare, this PR is for correctness sake)