### PR TITLE
To fix issue #108

### DIFF
--- a/build-requirements-3.3.txt
+++ b/build-requirements-3.3.txt
@@ -1,4 +1,5 @@
 python-coveralls
-tox<3.0
+pluggy<0.6
+tox<3
 wheel<0.30
 virtualenv==15.2.0

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -86,7 +86,7 @@ class VerifyingKey:
         # returns a list of verifying keys for this signature and message
         
         digest = hashfunc(data).digest()
-        return klass.from_public_key_recovery_with_digest(signature, digest, curve, hashfunc=sha1, sigdecode=sigdecode_string)
+        return klass.from_public_key_recovery_with_digest(signature, digest, curve, hashfunc=sha1, sigdecode=sigdecode)
 
     @classmethod
     def from_public_key_recovery_with_digest(klass, signature, digest, curve, hashfunc=sha1, sigdecode=sigdecode_string):


### PR DESCRIPTION
Fixed the issue that keys.py#Line89 using the wrong parameter
Downgrade `pluggy` to **0.5.2** while using Python33, so it can install `tox` successfully.