### PR TITLE
Fix wrong func in from_public_key_recovery()

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -81,12 +81,15 @@ class VerifyingKey:
         return klass.from_string(point_str[2:], curve)
 
     @classmethod
-    def from_public_key_recovery(klass, signature, data, curve, hashfunc=sha1, sigdecode=sigdecode_string):
+    def from_public_key_recovery(cls, signature, data, curve, hashfunc=sha1,
+                                sigdecode=sigdecode_string):
         # Given a signature and corresponding message this function
         # returns a list of verifying keys for this signature and message
         
         digest = hashfunc(data).digest()
-        return klass.from_public_key_recovery_with_digest(signature, digest, curve, hashfunc=sha1, sigdecode=sigdecode)
+        return cls.from_public_key_recovery_with_digest(
+            signature, digest, curve, hashfunc=hashfunc,
+            sigdecode=sigdecode)
 
     @classmethod
     def from_public_key_recovery_with_digest(klass, signature, digest, curve, hashfunc=sha1, sigdecode=sigdecode_string):

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -12,6 +12,9 @@ from six import PY3, b
 from hashlib import sha1
 
 
+__all__ = ["BadSignatureError", "BadDigestError", "VerifyingKey", "SigningKey"]
+
+
 class BadSignatureError(Exception):
     pass
 

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -337,7 +337,36 @@ class ECDSA(unittest.TestCase):
         # Test if original vk is the list of recovered keys
         self.assertTrue(
             vk.pubkey.point in [recovered_vk.pubkey.point for recovered_vk in recovered_vks])
-        
+
+    def test_public_key_recovery_with_custom_hash(self):
+        # Create keys
+        curve = NIST256p
+
+        sk = SigningKey.generate(curve=curve, hashfunc=sha256)
+        vk = sk.get_verifying_key()
+
+        # Sign a message
+        data = b("blahblah")
+        signature = sk.sign(data)
+
+        # Recover verifying keys
+        recovered_vks = VerifyingKey.\
+                from_public_key_recovery(signature, data, curve,
+                                         hashfunc=sha256)
+
+        # Test if each pk is valid
+        for recovered_vk in recovered_vks:
+            # Test if recovered vk is valid for the data
+            self.assertTrue(recovered_vk.verify(signature, data))
+
+            # Test if properties are equal
+            self.assertEqual(vk.curve, recovered_vk.curve)
+            self.assertEqual(sha256, recovered_vk.default_hashfunc)
+
+        # Test if original vk is the list of recovered keys
+        self.assertTrue(vk.pubkey.point in
+                [recovered_vk.pubkey.point for recovered_vk in recovered_vks])
+
 
 class OpenSSL(unittest.TestCase):
     # test interoperability with OpenSSL tools. Note that openssl's ECDSA


### PR DESCRIPTION
the call to klass.from_public_key_recovery_with_digest()
used the hardcoded sha1, effectively ignoring the hashfunc passed
as the paramter to from_public_key_recovery()

also use the canonical name of first parameter in classmethods