### PR TITLE
Support for X9.62 formatted public keys

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -55,8 +55,9 @@ class VerifyingKey:
         assert len(ys) == curve.baselen, (len(ys), curve.baselen)
         x = string_to_number(xs)
         y = string_to_number(ys)
-        if validate_point:
-            assert ecdsa.point_is_valid(curve.generator, x, y)
+        if validate_point and not ecdsa.point_is_valid(curve.generator, x, y):
+            raise MalformedPointError("Point does not lie on the curve")
+
         return ellipticcurve.Point(curve.curve, x, y, order)
 
     @staticmethod

--- a/src/ecdsa/numbertheory.py
+++ b/src/ecdsa/numbertheory.py
@@ -11,8 +11,12 @@
 
 from __future__ import division
 
-from six import integer_types
+from six import integer_types, PY3
 from six.moves import reduce
+try:
+    xrange
+except NameError:
+    xrange = range
 
 import math
 
@@ -62,7 +66,7 @@ def polynomial_reduce_mod(poly, polymod, p):
 
   while len(poly) >= len(polymod):
     if poly[-1] != 0:
-      for i in range(2, len(polymod) + 1):
+      for i in xrange(2, len(polymod) + 1):
         poly[-i] = (poly[-i] - poly[-1] * polymod[-i]) % p
     poly = poly[0:-1]
 
@@ -86,8 +90,8 @@ def polynomial_multiply_mod(m1, m2, polymod, p):
 
   # Add together all the cross-terms:
 
-  for i in range(len(m1)):
-    for j in range(len(m2)):
+  for i in xrange(len(m1)):
+    for j in xrange(len(m2)):
       prod[i + j] = (prod[i + j] + m1[i] * m2[j]) % p
 
   return polynomial_reduce_mod(prod, polymod, p)
@@ -187,7 +191,12 @@ def square_root_mod_prime(a, p):
       return (2 * a * modular_exp(4 * a, (p - 5) // 8, p)) % p
     raise RuntimeError("Shouldn't get here.")
 
-  for b in range(2, p):
+  if PY3:
+    range_top = p
+  else:
+    # xrange on python2 can take integers representable as C long only
+    range_top = min(0x7fffffff, p)
+  for b in xrange(2, range_top):
     if jacobi(b * b - 4 * a, p) == -1:
       f = (a, -b, 1)
       ff = polynomial_exp_mod((0, 1), (p + 1) // 2, f, p)
@@ -355,7 +364,7 @@ def carmichael_of_factorized(f_list):
     return 1
 
   result = carmichael_of_ppower(f_list[0])
-  for i in range(1, len(f_list)):
+  for i in xrange(1, len(f_list)):
     result = lcm(result, carmichael_of_ppower(f_list[i]))
 
   return result
@@ -477,7 +486,7 @@ def is_prime(n):
   while (r % 2) == 0:
     s = s + 1
     r = r // 2
-  for i in range(t):
+  for i in xrange(t):
     a = smallprimes[i]
     y = modular_exp(a, r, n)
     if y != 1 and y != n - 1:

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -416,6 +416,14 @@ class ECDSA(unittest.TestCase):
         with self.assertRaises(MalformedPointError):
             VerifyingKey.from_string(b('\x01') + enc[:24])
 
+    def test_decoding_with_point_not_on_curve(self):
+        enc = b('\x0c\xe0\x1d\xe0d\x1c\x8eS\x8a\xc0\x9eK\xa8x !\xd5\xc2\xc3'
+                '\xfd\xc8\xa0c\xff\xfb\x02\xb9\xc4\x84)\x1a\x0f\x8b\x87\xa4'
+                'z\x8a#\xb5\x97\xecO\xb6\xa0HQ\x89*')
+
+        with self.assertRaises(MalformedPointError):
+            VerifyingKey.from_string(enc[:47] + b('\x00'))
+
     def test_decoding_with_point_at_infinity(self):
         # decoding it is unsupported, as it's not necessary to encode it
         with self.assertRaises(MalformedPointError):

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -1,6 +1,9 @@
 from __future__ import with_statement, division
 
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import os
 import time
 import shutil
@@ -11,12 +14,14 @@ from hashlib import sha1, sha256, sha512
 
 from six import b, print_, binary_type
 from .keys import SigningKey, VerifyingKey
-from .keys import BadSignatureError
+from .keys import BadSignatureError, MalformedPointError
 from . import util
 from .util import sigencode_der, sigencode_strings
 from .util import sigdecode_der, sigdecode_strings
+from .util import number_to_string
 from .curves import Curve, UnknownCurveError
-from .curves import NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, SECP256k1
+from .curves import NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, \
+        SECP256k1, curves
 from .ellipticcurve import Point
 from . import der
 from . import rfc6979
@@ -366,6 +371,99 @@ class ECDSA(unittest.TestCase):
         # Test if original vk is the list of recovered keys
         self.assertTrue(vk.pubkey.point in
                 [recovered_vk.pubkey.point for recovered_vk in recovered_vks])
+
+    def test_encoding(self):
+        sk = SigningKey.from_secret_exponent(123456789)
+        vk = sk.verifying_key
+
+        exp = b('\x0c\xe0\x1d\xe0d\x1c\x8eS\x8a\xc0\x9eK\xa8x !\xd5\xc2\xc3'
+                '\xfd\xc8\xa0c\xff\xfb\x02\xb9\xc4\x84)\x1a\x0f\x8b\x87\xa4'
+                'z\x8a#\xb5\x97\xecO\xb6\xa0HQ\x89*')
+        self.assertEqual(vk.to_string(), exp)
+        self.assertEqual(vk.to_string('uncompressed'), b('\x04') + exp)
+        self.assertEqual(vk.to_string('compressed'), b('\x02') + exp[:24])
+
+    def test_decoding(self):
+        sk = SigningKey.from_secret_exponent(123456789)
+        vk = sk.verifying_key
+
+        enc = b('\x0c\xe0\x1d\xe0d\x1c\x8eS\x8a\xc0\x9eK\xa8x !\xd5\xc2\xc3'
+                '\xfd\xc8\xa0c\xff\xfb\x02\xb9\xc4\x84)\x1a\x0f\x8b\x87\xa4'
+                'z\x8a#\xb5\x97\xecO\xb6\xa0HQ\x89*')
+
+        from_raw = VerifyingKey.from_string(enc)
+        self.assertEqual(from_raw.pubkey.point, vk.pubkey.point)
+
+        from_uncompressed = VerifyingKey.from_string(b('\x04') + enc)
+        self.assertEqual(from_uncompressed.pubkey.point, vk.pubkey.point)
+
+        from_compressed = VerifyingKey.from_string(b('\x02') + enc[:24])
+        self.assertEqual(from_compressed.pubkey.point, vk.pubkey.point)
+
+    def test_decoding_with_malformed_uncompressed(self):
+        enc = b('\x0c\xe0\x1d\xe0d\x1c\x8eS\x8a\xc0\x9eK\xa8x !\xd5\xc2\xc3'
+                '\xfd\xc8\xa0c\xff\xfb\x02\xb9\xc4\x84)\x1a\x0f\x8b\x87\xa4'
+                'z\x8a#\xb5\x97\xecO\xb6\xa0HQ\x89*')
+
+        with self.assertRaises(MalformedPointError):
+            VerifyingKey.from_string(b('\x02') + enc)
+
+    def test_decoding_with_malformed_compressed(self):
+        enc = b('\x0c\xe0\x1d\xe0d\x1c\x8eS\x8a\xc0\x9eK\xa8x !\xd5\xc2\xc3'
+                '\xfd\xc8\xa0c\xff\xfb\x02\xb9\xc4\x84)\x1a\x0f\x8b\x87\xa4'
+                'z\x8a#\xb5\x97\xecO\xb6\xa0HQ\x89*')
+
+        with self.assertRaises(MalformedPointError):
+            VerifyingKey.from_string(b('\x01') + enc[:24])
+
+    def test_decoding_with_point_at_infinity(self):
+        # decoding it is unsupported, as it's not necessary to encode it
+        with self.assertRaises(MalformedPointError):
+            VerifyingKey.from_string(b('\x00'))
+
+    def test_not_lying_on_curve(self):
+        enc = number_to_string(NIST192p.order, NIST192p.order+1)
+
+        with self.assertRaises(MalformedPointError):
+            VerifyingKey.from_string(b('\x02') + enc)
+
+
+@pytest.mark.parametrize("val,even",
+        [(i, j) for i in range(256) for j in [True, False]])
+def test_VerifyingKey_decode_with_small_values(val, even):
+    enc = number_to_string(val, NIST192p.order)
+
+    if even:
+        enc = b('\x02') + enc
+    else:
+        enc = b('\x03') + enc
+
+    # small values can both be actual valid public keys and not, verify that
+    # only expected exceptions are raised if they are not
+    try:
+        vk = VerifyingKey.from_string(enc)
+        assert isinstance(vk, VerifyingKey)
+    except MalformedPointError:
+        assert True
+
+
+params = []
+for curve in curves:
+    for enc in ["raw", "uncompressed", "compressed"]:
+        params.append(pytest.param(curve, enc, id="{0}-{1}".format(
+            curve.name, enc)))
+
+
+@pytest.mark.parametrize("curve,encoding", params)
+def test_VerifyingKey_encode_decode(curve, encoding):
+    sk = SigningKey.generate(curve=curve)
+    vk = sk.verifying_key
+
+    encoded = vk.to_string(encoding)
+
+    from_enc = VerifyingKey.from_string(encoded, curve=curve)
+
+    assert vk.pubkey.point == from_enc.pubkey.point
 
 
 class OpenSSL(unittest.TestCase):


### PR DESCRIPTION
This is re-working of the PR #54 (which in turn is a reworking of #34).

This implements support for the compressed, uncompressed and hybrid format specified in X9.62 and the SEC1 standards

http://www.secg.org/sec1-v2.pdf

fixes #1, #53 
closes #54, #34 

I'm not adding documentation as I plan to do that either in #117 or after #117 is merged