### PR TITLE
add MalformedPointError to __all__

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -14,7 +14,8 @@ from six import PY3, b
 from hashlib import sha1
 
 
-__all__ = ["BadSignatureError", "BadDigestError", "VerifyingKey", "SigningKey"]
+__all__ = ["BadSignatureError", "BadDigestError", "VerifyingKey", "SigningKey",
+           "MalformedPointError"]
 
 
 class BadSignatureError(Exception):


### PR DESCRIPTION
MalformedPointError can be raised by public methods, so it should get
imported with "*"