### PR TITLE
Backport signature decode

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,5 @@ omit =
  ecdsa/six.py
  ecdsa/_version.py
  ecdsa/test_ecdsa.py
+ ecdsa/test_der.py
+ ecdsa/test_malformed_sigs.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# workaround for 3.7 not available in default configuration
+# travis-ci/travis-ci#9815
+dist: trusty
 language: python
 python:
   - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 # workaround for 3.7 not available in default configuration
 # travis-ci/travis-ci#9815
 dist: trusty
+sudo: false
 language: python
+cache: pip
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
 python:
   - "2.6"
   - "2.7"
@@ -14,6 +18,8 @@ install:
   - if [[ -e build-requirements-${TRAVIS_PYTHON_VERSION}.txt ]]; then travis_retry pip install -r build-requirements-${TRAVIS_PYTHON_VERSION}.txt; else travis_retry pip install -r build-requirements.txt; fi
 script:
   - coverage run setup.py test
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.2 && ! $TRAVIS_PYTHON_VERSION =~ py ]]; then tox -e py${TRAVIS_PYTHON_VERSION/./}; fi
+  - if [[ $TRAVIS_PYTHON_VERSION =~ py ]]; then tox -e $TRAVIS_PYTHON_VERSION; fi
   - python setup.py speed
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ There are four test suites, three for the original Pearson module, and one
 more for the wrapper. To run them all, do this:
 
     python setup.py test
+    tox -e coverage
 
 On my 2014 Mac Mini, the combined tests take about 20 seconds to run. On a
 2.4GHz P4 Linux box, they take 81 seconds.
@@ -118,7 +119,8 @@ is to call `s=sk.to_string()`, and then re-create it with
 `SigningKey.from_string(s, curve)` . This short form does not record the
 curve, so you must be sure to tell from_string() the same curve you used for
 the original key. The short form of a NIST192p-based signing key is just 24
-bytes long.
+bytes long. If the point encoding is invalid or it does not lie on the
+specified curve, `from_string()` will raise MalformedPointError.
 
     from ecdsa import SigningKey, NIST384p
     sk = SigningKey.generate(curve=NIST384p)
@@ -132,7 +134,8 @@ formats that OpenSSL uses. The PEM file looks like the familiar ASCII-armored
 is a shorter binary form of the same data.
 `SigningKey.from_pem()/.from_der()` will undo this serialization. These
 formats include the curve name, so you do not need to pass in a curve
-identifier to the deserializer.
+identifier to the deserializer. In case the file is malformed `from_der()`
+and `from_pem()` will raise UnexpectedDER or MalformedPointError.
 
     from ecdsa import SigningKey, NIST384p
     sk = SigningKey.generate(curve=NIST384p)

--- a/build-requirements-2.6.txt
+++ b/build-requirements-2.6.txt
@@ -1,3 +1,4 @@
 tox
 coveralls<1.3.0
 idna<2.8
+unittest2

--- a/build-requirements-3.2.txt
+++ b/build-requirements-3.2.txt
@@ -7,3 +7,4 @@ PyYAML<3.13
 tox<3.0
 wheel<0.30
 virtualenv==15.2.0
+pytest>2.7.3

--- a/build-requirements-3.3.txt
+++ b/build-requirements-3.3.txt
@@ -2,3 +2,4 @@ python-coveralls
 tox<3.0
 wheel<0.30
 virtualenv==15.2.0
+pluggy<0.6

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,1 +1,4 @@
 python-coveralls
+pytest>3.0.7
+pytest-cov<2.7.0
+tox

--- a/ecdsa/__init__.py
+++ b/ecdsa/__init__.py
@@ -1,9 +1,12 @@
 __all__ = ["curves", "der", "ecdsa", "ellipticcurve", "keys", "numbertheory",
            "test_pyecdsa", "util", "six"]
-from .keys import SigningKey, VerifyingKey, BadSignatureError, BadDigestError
+from .keys import SigningKey, VerifyingKey, BadSignatureError, BadDigestError,\
+        MalformedPointError
 from .curves import NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, SECP256k1
+from .der import UnexpectedDER
 
 _hush_pyflakes = [SigningKey, VerifyingKey, BadSignatureError, BadDigestError,
+                  MalformedPointError, UnexpectedDER,
                   NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, SECP256k1]
 del _hush_pyflakes
 

--- a/ecdsa/der.py
+++ b/ecdsa/der.py
@@ -60,10 +60,15 @@ def remove_constructed(string):
     return tag, body, rest
 
 def remove_sequence(string):
+    if not string:
+        raise UnexpectedDER("Empty string does not encode a sequence")
     if not string.startswith(b("\x30")):
-        n = string[0] if isinstance(string[0], integer_types) else ord(string[0])
-        raise UnexpectedDER("wanted sequence (0x30), got 0x%02x" % n)
+        n = string[0] if isinstance(string[0], integer_types) else \
+                ord(string[0])
+        raise UnexpectedDER("wanted type 'sequence' (0x30), got 0x%02x" % n)
     length, lengthlength = read_length(string[1:])
+    if length > len(string) - 1 - lengthlength:
+        raise UnexpectedDER("Length longer than the provided buffer")
     endseq = 1+lengthlength+length
     return string[1+lengthlength:endseq], string[endseq:]
 
@@ -96,14 +101,24 @@ def remove_object(string):
     return tuple(numbers), rest
 
 def remove_integer(string):
+    if not string:
+        raise UnexpectedDER("Empty string is an invalid encoding of an "
+                            "integer")
     if not string.startswith(b("\x02")):
-        n = string[0] if isinstance(string[0], integer_types) else ord(string[0])
-        raise UnexpectedDER("wanted integer (0x02), got 0x%02x" % n)
+        n = string[0] if isinstance(string[0], integer_types) \
+                else ord(string[0])
+        raise UnexpectedDER("wanted type 'integer' (0x02), got 0x%02x" % n)
     length, llen = read_length(string[1:])
+    if length > len(string) - 1 - llen:
+        raise UnexpectedDER("Length longer than provided buffer")
+    if length == 0:
+        raise UnexpectedDER("0-byte long encoding of integer")
     numberbytes = string[1+llen:1+llen+length]
     rest = string[1+llen+length:]
-    nbytes = numberbytes[0] if isinstance(numberbytes[0], integer_types) else ord(numberbytes[0])
-    assert nbytes < 0x80 # can't support negative numbers yet
+    nbytes = numberbytes[0] if isinstance(numberbytes[0], integer_types) \
+            else ord(numberbytes[0])
+    if not nbytes < 0x80:
+        raise UnexpectedDER("Negative integers are not supported")
     return int(binascii.hexlify(numberbytes), 16), rest
 
 def read_number(string):

--- a/ecdsa/der.py
+++ b/ecdsa/der.py
@@ -148,6 +148,8 @@ def encode_length(l):
     return int2byte(0x80|llen) + s
 
 def read_length(string):
+    if not string:
+        raise UnexpectedDER("Empty string can't encode valid length value")
     num = string[0] if isinstance(string[0], integer_types) else ord(string[0])
     if not (num & 0x80):
         # short form
@@ -155,6 +157,8 @@ def read_length(string):
     # else long-form: b0&0x7f is number of additional base256 length bytes,
     # big-endian
     llen = num & 0x7f
+    if not llen:
+        raise UnexpectedDER("Invalid length encoding, length byte is 0")
     if llen > len(string)-1:
         raise UnexpectedDER("ran out of length bytes")
     return int(binascii.hexlify(string[1:1+llen]), 16), 1+llen

--- a/ecdsa/der.py
+++ b/ecdsa/der.py
@@ -115,9 +115,9 @@ def remove_integer(string):
         raise UnexpectedDER("0-byte long encoding of integer")
     numberbytes = string[1+llen:1+llen+length]
     rest = string[1+llen+length:]
-    nbytes = numberbytes[0] if isinstance(numberbytes[0], integer_types) \
+    msb = numberbytes[0] if isinstance(numberbytes[0], integer_types) \
             else ord(numberbytes[0])
-    if not nbytes < 0x80:
+    if not msb < 0x80:
         raise UnexpectedDER("Negative integers are not supported")
     return int(binascii.hexlify(numberbytes), 16), rest
 

--- a/ecdsa/der.py
+++ b/ecdsa/der.py
@@ -119,6 +119,15 @@ def remove_integer(string):
             else ord(numberbytes[0])
     if not msb < 0x80:
         raise UnexpectedDER("Negative integers are not supported")
+    # check if the encoding is the minimal one (DER requirement)
+    if length > 1 and not msb:
+        # leading zero byte is allowed if the integer would have been
+        # considered a negative number otherwise
+        smsb = numberbytes[1] if isinstance(numberbytes[1], integer_types) \
+                else ord(numberbytes[1])
+        if smsb < 0x80:
+            raise UnexpectedDER("Invalid encoding of integer, unnecessary "
+                                "zero padding bytes")
     return int(binascii.hexlify(numberbytes), 16), rest
 
 def read_number(string):
@@ -158,9 +167,13 @@ def read_length(string):
     # big-endian
     llen = num & 0x7f
     if not llen:
-        raise UnexpectedDER("Invalid length encoding, length byte is 0")
+        raise UnexpectedDER("Invalid length encoding, length of length is 0")
     if llen > len(string)-1:
-        raise UnexpectedDER("ran out of length bytes")
+        raise UnexpectedDER("Length of length longer than provided buffer")
+    # verify that the encoding is minimal possible (DER requirement)
+    msb = string[1] if isinstance(string[1], integer_types) else ord(string[1])
+    if not msb or llen == 1 and msb < 0x80:
+        raise UnexpectedDER("Not minimal encoding of length")
     return int(binascii.hexlify(string[1:1+llen]), 16), 1+llen
 
 def remove_bitstring(string):

--- a/ecdsa/keys.py
+++ b/ecdsa/keys.py
@@ -106,11 +106,14 @@ class VerifyingKey:
                                  "for your digest (%d)" % (self.curve.name,
                                                            8*len(digest)))
         number = string_to_number(digest)
-        r, s = sigdecode(signature, self.pubkey.order)
+        try:
+            r, s = sigdecode(signature, self.pubkey.order)
+        except der.UnexpectedDER as e:
+            raise BadSignatureError("Malformed formatting of signature", e)
         sig = ecdsa.Signature(r, s)
         if self.pubkey.verifies(number, sig):
             return True
-        raise BadSignatureError
+        raise BadSignatureError("Signature verification failed")
 
 class SigningKey:
     def __init__(self, _error__please_use_generate=None):

--- a/ecdsa/keys.py
+++ b/ecdsa/keys.py
@@ -6,7 +6,7 @@ from . import rfc6979
 from .curves import NIST192p, find_curve
 from .util import string_to_number, number_to_string, randrange
 from .util import sigencode_string, sigdecode_string
-from .util import oid_ecPublicKey, encoded_oid_ecPublicKey
+from .util import oid_ecPublicKey, encoded_oid_ecPublicKey, MalformedSignature
 from .six import PY3, b
 from hashlib import sha1
 
@@ -108,7 +108,7 @@ class VerifyingKey:
         number = string_to_number(digest)
         try:
             r, s = sigdecode(signature, self.pubkey.order)
-        except der.UnexpectedDER as e:
+        except (der.UnexpectedDER, MalformedSignature) as e:
             raise BadSignatureError("Malformed formatting of signature", e)
         sig = ecdsa.Signature(r, s)
         if self.pubkey.verifies(number, sig):

--- a/ecdsa/test_der.py
+++ b/ecdsa/test_der.py
@@ -1,0 +1,88 @@
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+from .der import remove_integer, UnexpectedDER, read_length
+from six import b
+
+class TestRemoveInteger(unittest.TestCase):
+    # DER requires the integers to be 0-padded only if they would be
+    # interpreted as negative, check if those errors are detected
+    def test_non_minimal_encoding(self):
+        with self.assertRaises(UnexpectedDER):
+            remove_integer(b('\x02\x02\x00\x01'))
+
+    def test_negative_with_high_bit_set(self):
+        with self.assertRaises(UnexpectedDER):
+            remove_integer(b('\x02\x01\x80'))
+
+    def test_two_zero_bytes_with_high_bit_set(self):
+        with self.assertRaises(UnexpectedDER):
+            remove_integer(b('\x02\x03\x00\x00\xff'))
+
+    def test_zero_length_integer(self):
+        with self.assertRaises(UnexpectedDER):
+            remove_integer(b('\x02\x00'))
+
+    def test_empty_string(self):
+        with self.assertRaises(UnexpectedDER):
+            remove_integer(b(''))
+
+    def test_encoding_of_zero(self):
+        val, rem = remove_integer(b('\x02\x01\x00'))
+
+        self.assertEqual(val, 0)
+        self.assertFalse(rem)
+
+    def test_encoding_of_127(self):
+        val, rem = remove_integer(b('\x02\x01\x7f'))
+
+        self.assertEqual(val, 127)
+        self.assertFalse(rem)
+
+    def test_encoding_of_128(self):
+        val, rem = remove_integer(b('\x02\x02\x00\x80'))
+
+        self.assertEqual(val, 128)
+        self.assertFalse(rem)
+
+
+class TestReadLength(unittest.TestCase):
+    # DER requires the lengths between 0 and 127 to be encoded using the short
+    # form and lengths above that encoded with minimal number of bytes
+    # necessary
+    def test_zero_length(self):
+        self.assertEqual((0, 1), read_length(b('\x00')))
+
+    def test_two_byte_zero_length(self):
+        with self.assertRaises(UnexpectedDER):
+            read_length(b('\x81\x00'))
+
+    def test_two_byte_small_length(self):
+        with self.assertRaises(UnexpectedDER):
+            read_length(b('\x81\x7f'))
+
+    def test_long_form_with_zero_length(self):
+        with self.assertRaises(UnexpectedDER):
+            read_length(b('\x80'))
+
+    def test_smallest_two_byte_length(self):
+        self.assertEqual((128, 2), read_length(b('\x81\x80')))
+
+    def test_zero_padded_length(self):
+        with self.assertRaises(UnexpectedDER):
+            read_length(b('\x82\x00\x80'))
+
+    def test_two_three_byte_length(self):
+        self.assertEqual((256, 3), read_length(b'\x82\x01\x00'))
+
+    def test_empty_string(self):
+        with self.assertRaises(UnexpectedDER):
+            read_length(b(''))
+
+    def test_length_overflow(self):
+        with self.assertRaises(UnexpectedDER):
+            read_length(b('\x83\x01\x00'))

--- a/ecdsa/test_der.py
+++ b/ecdsa/test_der.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import unittest
 from .der import remove_integer, UnexpectedDER, read_length
-from six import b
+from .six import b
 
 class TestRemoveInteger(unittest.TestCase):
     # DER requires the integers to be 0-padded only if they would be

--- a/ecdsa/test_malformed_sigs.py
+++ b/ecdsa/test_malformed_sigs.py
@@ -3,7 +3,7 @@ from __future__ import with_statement, division
 import pytest
 import hashlib
 
-from six import b, binary_type
+from .six import b, binary_type
 from .keys import SigningKey, VerifyingKey
 from .keys import BadSignatureError
 from .util import sigencode_der, sigencode_string

--- a/ecdsa/test_malformed_sigs.py
+++ b/ecdsa/test_malformed_sigs.py
@@ -1,28 +1,16 @@
 from __future__ import with_statement, division
 
-import unittest
-import os
-import time
-import shutil
-import subprocess
 import pytest
-from binascii import hexlify, unhexlify
-from hashlib import sha1, sha256, sha512
 import hashlib
 
 from six import b, binary_type
 from .keys import SigningKey, VerifyingKey
 from .keys import BadSignatureError
-from . import util
-from .util import sigencode_der, sigencode_strings
-from .util import sigdecode_der, sigdecode_strings
+from .util import sigencode_der, sigencode_string
+from .util import sigdecode_der, sigdecode_string
 from .curves import curves, NIST256p, NIST521p
-from .ellipticcurve import Point
-from . import der
-from . import rfc6979
-import copy
 
-sigs = []
+der_sigs = []
 example_data = b("some data to sign")
 
 # Just NIST256p with SHA256 is 560 test cases, all curves with all hashes is
@@ -37,14 +25,14 @@ for curve in [NIST256p]:
                              sigencode=sigencode_der)
         for pos in range(len(signature)):
             for xor in (1<<i for i in range(8)):
-                sigs.append(pytest.param(
+                der_sigs.append(pytest.param(
                     key.verifying_key, hash_alg,
                     signature, pos, xor,
                     id="{0}-{1}-pos-{2}-xor-{3}".format(
                         curve.name, hash_alg, pos, xor)))
 
 
-@pytest.mark.parametrize("verifying_key,hash_alg,signature,pos,xor", sigs)
+@pytest.mark.parametrize("verifying_key,hash_alg,signature,pos,xor", der_sigs)
 def test_fuzzed_der_signatures(verifying_key, hash_alg, signature, pos, xor):
     # check if a malformed DER encoded signature causes the same exception
     # to be raised irrespective of the type of error
@@ -60,9 +48,40 @@ def test_fuzzed_der_signatures(verifying_key, hash_alg, signature, pos, xor):
         assert True
 
 
-def __main__():
-    unittest.main()
+####
+#
+# For string encoded signatures, only the length of string is important
+#
+####
+
+str_sigs = []
+
+#for curve in curves:
+for curve in [NIST256p]:
+    #for hash_alg in ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"]:
+    for hash_alg in ["sha256"]:
+        key = SigningKey.generate(curve)
+        signature = key.sign(example_data, hashfunc=getattr(hashlib, hash_alg),
+                             sigencode=sigencode_string)
+        for trunc in range(len(signature)):
+            str_sigs.append(pytest.param(
+                key.verifying_key, hash_alg,
+                signature, trunc,
+                id="{0}-{1}-trunc-{2}".format(
+                    curve.name, hash_alg, trunc)))
 
 
-if __name__ == "__main__":
-    __main__()
+@pytest.mark.parametrize("verifying_key,hash_alg,signature,trunc", str_sigs)
+def test_truncated_string_signatures(verifying_key, hash_alg, signature, trunc):
+    # check if a malformed string encoded signature causes the same exception
+    # to be raised irrespective of the type of error
+    sig = bytearray(signature)
+    sig = sig[:trunc]
+    sig = binary_type(sig)
+
+    try:
+        verifying_key.verify(sig, example_data, getattr(hashlib, hash_alg),
+                             sigdecode_string)
+        assert False
+    except BadSignatureError:
+        assert True

--- a/ecdsa/test_malformed_sigs.py
+++ b/ecdsa/test_malformed_sigs.py
@@ -1,0 +1,68 @@
+from __future__ import with_statement, division
+
+import unittest
+import os
+import time
+import shutil
+import subprocess
+import pytest
+from binascii import hexlify, unhexlify
+from hashlib import sha1, sha256, sha512
+import hashlib
+
+from six import b, binary_type
+from .keys import SigningKey, VerifyingKey
+from .keys import BadSignatureError
+from . import util
+from .util import sigencode_der, sigencode_strings
+from .util import sigdecode_der, sigdecode_strings
+from .curves import curves, NIST256p, NIST521p
+from .ellipticcurve import Point
+from . import der
+from . import rfc6979
+import copy
+
+sigs = []
+example_data = b("some data to sign")
+
+# Just NIST256p with SHA256 is 560 test cases, all curves with all hashes is
+# few thousand slow test cases; execute the most interesting only
+
+#for curve in curves:
+for curve in [NIST256p]:
+    #for hash_alg in ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"]:
+    for hash_alg in ["sha256"]:
+        key = SigningKey.generate(curve)
+        signature = key.sign(example_data, hashfunc=getattr(hashlib, hash_alg),
+                             sigencode=sigencode_der)
+        for pos in range(len(signature)):
+            for xor in (1<<i for i in range(8)):
+                sigs.append(pytest.param(
+                    key.verifying_key, hash_alg,
+                    signature, pos, xor,
+                    id="{0}-{1}-pos-{2}-xor-{3}".format(
+                        curve.name, hash_alg, pos, xor)))
+
+
+@pytest.mark.parametrize("verifying_key,hash_alg,signature,pos,xor", sigs)
+def test_fuzzed_der_signatures(verifying_key, hash_alg, signature, pos, xor):
+    # check if a malformed DER encoded signature causes the same exception
+    # to be raised irrespective of the type of error
+    sig = bytearray(signature)
+    sig[pos] ^= xor
+    sig = binary_type(sig)
+
+    try:
+        verifying_key.verify(sig, example_data, getattr(hashlib, hash_alg),
+                             sigdecode_der)
+        assert False
+    except BadSignatureError:
+        assert True
+
+
+def __main__():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    __main__()

--- a/ecdsa/test_malformed_sigs.py
+++ b/ecdsa/test_malformed_sigs.py
@@ -17,7 +17,7 @@ example_data = b("some data to sign")
 # few thousand slow test cases; execute the most interesting only
 
 #for curve in curves:
-for curve in [NIST256p]:
+for curve in [NIST521p]:
     #for hash_alg in ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"]:
     for hash_alg in ["sha256"]:
         key = SigningKey.generate(curve)

--- a/ecdsa/util.py
+++ b/ecdsa/util.py
@@ -216,18 +216,38 @@ def sigencode_der_canonize(r, s, order):
     return sigencode_der(r, s, order)
 
 
+class MalformedSignature(Exception):
+    pass
+
+
 def sigdecode_string(signature, order):
     l = orderlen(order)
-    assert len(signature) == 2*l, (len(signature), 2*l)
+    if not len(signature) == 2 * l:
+        raise MalformedSignature(
+                "Invalid length of signature, expected {0} bytes long, "
+                "provided string is {1} bytes long"
+                .format(2 * l, len(signature)))
     r = string_to_number_fixedlen(signature[:l], order)
     s = string_to_number_fixedlen(signature[l:], order)
     return r, s
 
 def sigdecode_strings(rs_strings, order):
+    if not len(rs_strings) == 2:
+        raise MalformedSignature(
+                "Invalid number of strings provided: {0}, expected 2"
+                .format(len(rs_strings)))
     (r_str, s_str) = rs_strings
     l = orderlen(order)
-    assert len(r_str) == l, (len(r_str), l)
-    assert len(s_str) == l, (len(s_str), l)
+    if not len(r_str) == l:
+        raise MalformedSignature(
+                "Invalid length of first string ('r' parameter), "
+                "expected {0} bytes long, provided string is {1} bytes long"
+                .format(l, len(r_str)))
+    if not len(s_str) == l:
+        raise MalformedSignature(
+                "Invalid length of second string ('s' parameter), "
+                "expected {0} bytes long, provided string is {1} bytes long"
+                .format(l, len(s_str)))
     r = string_to_number_fixedlen(r_str, order)
     s = string_to_number_fixedlen(s_str, order)
     return r, s

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py26, py27, py33, py34, py35, py36, py37, pypy, pypy3
+
+
+[testenv]
+deps =
+     py{33}: py<1.5
+     py{33}: pytest<3.3
+     py{26}: unittest2
+     py{26,27,34,35,36,37,py,py3}: pytest
+     py{33}: wheel<0.30
+     coverage
+
+commands = coverage run --branch -m pytest
+
+[testenv:coverage]
+sitepackages=True
+commands = coverage run --branch -m pytest


### PR DESCRIPTION
Backport the recent fixes to signature decoding.

See #114 

also harden the public and private key decoding (partial backport of #118)