### PR TITLE
Apply nonce bit-length mitigation to stop timing leakage.

### DIFF
--- a/src/ecdsa/curves.py
+++ b/src/ecdsa/curves.py
@@ -1,14 +1,18 @@
 from __future__ import division
 
 from . import der, ecdsa
+from .util import orderlen
+
+
+# orderlen was defined in this module previously, so keep it in __all__,
+# will need to mark it as deprecated later
+__all__ = ["UnknownCurveError", "orderlen", "Curve", "NIST192p",
+           "NIST224p", "NIST256p", "NIST384p", "NIST521p", "curves",
+           "find_curve"]
 
 
 class UnknownCurveError(Exception):
     pass
-
-
-def orderlen(order):
-    return (1+len("%x" % order))//2  # bytes
 
 
 # the NIST curves

--- a/src/ecdsa/ecdsa.py
+++ b/src/ecdsa/ecdsa.py
@@ -56,6 +56,7 @@ Written in 2005 by Peter Pearson and placed in the public domain.
 from six import int2byte, b
 from . import ellipticcurve
 from . import numbertheory
+from .util import bit_length
 
 
 class RSZeroError(RuntimeError):
@@ -171,7 +172,15 @@ class Private_key(object):
     G = self.public_key.generator
     n = G.order()
     k = random_k % n
-    p1 = k * G
+    # Fix the bit-length of the random nonce,
+    # so that it doesn't leak via timing.
+    # This does not change that ks = k mod n
+    ks = k + n
+    kt = ks + n
+    if bit_length(ks) == bit_length(n):
+      p1 = kt * G
+    else:
+      p1 = ks * G
     r = p1.x() % n
     if r == 0:
       raise RSZeroError("amazingly unlucky random number r")

--- a/src/ecdsa/ellipticcurve.py
+++ b/src/ecdsa/ellipticcurve.py
@@ -86,6 +86,9 @@ class Point(object):
     else:
       return False
 
+  def __neg__(self):
+    return Point(self.__curve, self.__x, self.__curve.p() - self.__y)
+
   def __add__(self, other):
     """Add one point to another point."""
 
@@ -123,13 +126,12 @@ class Point(object):
       return result // 2
 
     e = other
-    if self.__order:
-      e = e % self.__order
-    if e == 0:
+    if e == 0 or (self.__order and e % self.__order == 0):
       return INFINITY
     if self == INFINITY:
       return INFINITY
-    assert e > 0
+    if e < 0:
+      return (-self) * (-e)
 
     # From X9.62 D.3.2:
 

--- a/src/ecdsa/rfc6979.py
+++ b/src/ecdsa/rfc6979.py
@@ -11,15 +11,13 @@ Many thanks to Coda Hale for his implementation in Go language:
 
 import hmac
 from binascii import hexlify
-from .util import number_to_string, number_to_string_crop
+from .util import number_to_string, number_to_string_crop, bit_length
 from six import b
 
 
-def bit_length(num):
-    # http://docs.python.org/dev/library/stdtypes.html#int.bit_length
-    s = bin(num)  # binary representation:  bin(-37) --> '-0b100101'
-    s = s.lstrip('-0b')  # remove leading zeros and minus sign
-    return len(s)  # len('100101') --> 6
+# bit_length was defined in this module previously so keep it for backwards
+# compatibility, will need to deprecate and remove it later
+__all__ = ["bit_length", "bits2int", "bits2octets", "generate_k"]
 
 
 def bits2int(data, qlen):

--- a/src/ecdsa/util.py
+++ b/src/ecdsa/util.py
@@ -5,7 +5,6 @@ import math
 import binascii
 from hashlib import sha256
 from . import der
-from .curves import orderlen
 from six import PY3, int2byte, b, next
 
 # RFC5480:
@@ -15,6 +14,17 @@ from six import PY3, int2byte, b, next
 
 oid_ecPublicKey = (1, 2, 840, 10045, 2, 1)
 encoded_oid_ecPublicKey = der.encode_oid(*oid_ecPublicKey)
+
+
+def bit_length(num):
+    # http://docs.python.org/dev/library/stdtypes.html#int.bit_length
+    s = bin(num)  # binary representation:  bin(-37) --> '-0b100101'
+    s = s.lstrip('-0b')  # remove leading zeros and minus sign
+    return len(s)  # len('100101') --> 6
+
+
+def orderlen(order):
+    return (1+len("%x" % order))//2  # bytes
 
 
 def randrange(order, entropy=None):


### PR DESCRIPTION
This should be a mitigation for the Minerva attack. See https://minerva.crocs.fi.muni.cz for more info.