### PR TITLE
uplift NEWS from 0.13 branch

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+* Release 0.13.3 (07 Oct 2019)
+
+Fix CVE-2019-14853 - possible DoS caused by malformed signature decoding and
+signature malleability.
+
+Also harden key decoding from string and DER encodings.
+
+* Release 0.13.2 (17 Apr 2019)
+
+Restore compatibility of setup.py with Python 2.6 and 2.7.
+
+* Release 0.13.1 (17 Apr 2019)
+
+Fix the PyPI wheel - the old version included .pyc files.
+
 * Release 0.13 (07 Feb 2015)
 
 Fix the argument order for Curve constructor (put openssl_name= at the end,


### PR DESCRIPTION
keep the NEWS file up to date compared to 0.13 branch