### PR TITLE
make pypy and pypy3 support official

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
         env: TOX_ENV=pypy
       - python: pypy3
         env: TOX_ENV=pypy3
-  allow_failures:
-    - python: "pypy3"
 
 install:
   - pip list

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ it would not be too hard to add more.
 ## Dependencies
 
 This library uses only Python and the 'six' package. It is compatible with
-Python 2.6, 2.7 and 3.3+.
+Python 2.6, 2.7 and 3.3+. It also supports execution on the alternative
+implementaions like pypy and pypy3
 
 To run the OpenSSL compatibility tests, the 'openssl' tool must be on your
 $PATH. This release has been tested successfully against both OpenSSL 0.9.8o


### PR DESCRIPTION
Designate pypy and pypy3 execution environments as official.

fixes #98 