### PR TITLE
don't allow for creation of malformed DER files

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -226,6 +226,8 @@ class VerifyingKey:
         return der.topem(self.to_der(), "PUBLIC KEY")
 
     def to_der(self, point_encoding="uncompressed"):
+        if point_encoding == "raw":
+            raise ValueError("raw point_encoding not allowed in DER")
         point_str = b("\x00") + self.to_string(point_encoding)
         return der.encode_sequence(der.encode_sequence(encoded_oid_ecPublicKey,
                                                        self.curve.encoded_oid),
@@ -356,6 +358,8 @@ class SigningKey:
     def to_der(self, point_encoding="uncompressed"):
         # SEQ([int(1), octetstring(privkey),cont[0], oid(secp224r1),
         #      cont[1],bitstring])
+        if point_encoding == "raw":
+            raise ValueError("raw encoding not allowed in DER")
         encoded_vk = b("\x00") + \
                 self.get_verifying_key().to_string(point_encoding)
         return der.encode_sequence(der.encode_integer(1),

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -277,6 +277,19 @@ class ECDSA(unittest.TestCase):
         pub2 = VerifyingKey.from_pem(pem)
         self.assertTruePubkeysEqual(pub1, pub2)
 
+    def test_vk_to_der_with_invalid_point_encoding(self):
+        sk = SigningKey.generate()
+        vk = sk.verifying_key
+
+        with self.assertRaises(ValueError):
+            vk.to_der("raw")
+
+    def test_sk_to_der_with_invalid_point_encoding(self):
+        sk = SigningKey.generate()
+
+        with self.assertRaises(ValueError):
+            sk.to_der("raw")
+
     def test_vk_from_der_garbage_after_curve_oid(self):
         type_oid_der = encoded_oid_ecPublicKey
         curve_oid_der = der.encode_oid(*(1, 2, 840, 10045, 3, 1, 1)) + \


### PR DESCRIPTION
when encoding in ASN.1 the public point has to use uncompressed,
compressed or hybrid representation, raw is not allowed
so disallow it in API

fixes #136 