### PR TITLE
Bytes-like object support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ script:
         instrumental -f .instrumental.cov -s
         instrumental -f .instrumental.cov -s | python diff-instrumental.py --save .diff-instrumental
         git checkout $BRANCH
+        files="$(ls src/ecdsa/test*.py | grep -v test_malformed_sigs.py)"
         instrumental -t ecdsa -i 'test.*|.*_version' `which pytest` $files
         instrumental -f .instrumental.cov -sr
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
          TRAVIS_COMMIT_RANGE=$PR_FIRST^..$TRAVIS_COMMIT
        fi
   # sanity check current commit
-  - git rev-parse HEAD
+  - BRANCH=$(git rev-parse HEAD)
   - echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
   - git fetch origin master:refs/remotes/origin/master
 
@@ -78,7 +78,6 @@ install:
 script:
   - if [[ $TOX_ENV ]]; then tox -e $TOX_ENV; fi
   - tox -e speed
-  - cp diff-instrumental.py diff-instrumental-2.py
   - |
       if [[ $INSTRUMENTAL && $TRAVIS_PULL_REQUEST != "false" ]]; then
         git checkout $PR_FIRST^
@@ -86,8 +85,8 @@ script:
         files="$(ls src/ecdsa/test*.py | grep -v test_malformed_sigs.py)"
         instrumental -t ecdsa -i 'test.*|.*_version' `which pytest` $files
         instrumental -f .instrumental.cov -s
-        instrumental -f .instrumental.cov -s | python diff-instrumental-2.py --save .diff-instrumental
-        git checkout $TRAVIS_COMMIT
+        instrumental -f .instrumental.cov -s | python diff-instrumental.py --save .diff-instrumental
+        git checkout $BRANCH
         instrumental -t ecdsa -i 'test.*|.*_version' `which pytest` $files
         instrumental -f .instrumental.cov -sr
       fi
@@ -98,11 +97,11 @@ script:
         instrumental -t ecdsa -i 'test.*|.*_version' `which pytest` $files
         instrumental -f .instrumental.cov -s
         # just log the values when merging
-        instrumental -f .instrumental.cov -s | python diff-instrumental-2.py
+        instrumental -f .instrumental.cov -s | python diff-instrumental.py
       fi
   - |
       if [[ $INSTRUMENTAL && $TRAVIS_PULL_REQUEST != "false" ]]; then
-          instrumental -f .instrumental.cov -s | python diff-instrumental-2.py --read .diff-instrumental --fail-under 70 --max-difference -0.1
+          instrumental -f .instrumental.cov -s | python diff-instrumental.py --read .diff-instrumental --fail-under 70 --max-difference -0.1
       fi
 after_success:
   - if [[ -z $INSTRUMENTAL ]]; then coveralls; fi

--- a/src/ecdsa/_compat.py
+++ b/src/ecdsa/_compat.py
@@ -1,0 +1,16 @@
+"""
+Common functions for providing cross-python version compatibility.
+"""
+import sys
+
+
+if sys.version_info < (3, 0):
+    def normalise_bytes(buffer_object):
+        """Cast the input into array of bytes."""
+        return buffer(buffer_object)
+
+
+else:
+    def normalise_bytes(buffer_object):
+        """Cast the input into array of bytes."""
+        return memoryview(buffer_object).cast('B')

--- a/src/ecdsa/_compat.py
+++ b/src/ecdsa/_compat.py
@@ -2,6 +2,15 @@
 Common functions for providing cross-python version compatibility.
 """
 import sys
+from six import integer_types
+
+
+def str_idx_as_int(string, index):
+    """Take index'th byte from string, return as integer"""
+    val = string[index]
+    if isinstance(val, integer_types):
+        return val
+    return ord(val)
 
 
 if sys.version_info < (3, 0):

--- a/src/ecdsa/_compat.py
+++ b/src/ecdsa/_compat.py
@@ -18,8 +18,21 @@ if sys.version_info < (3, 0):
         """Cast the input into array of bytes."""
         return buffer(buffer_object)
 
+    def hmac_compat(ret):
+        return ret
 
 else:
+    if sys.version_info < (3, 4):
+        # on python 3.3 hmac.hmac.update() accepts only bytes, on newer
+        # versions it does accept memoryview() also
+        def hmac_compat(data):
+            if not isinstance(data, bytes):
+                return bytes(data)
+            return data
+    else:
+        def hmac_compat(data):
+            return data
+
     def normalise_bytes(buffer_object):
         """Cast the input into array of bytes."""
         return memoryview(buffer_object).cast('B')

--- a/src/ecdsa/der.py
+++ b/src/ecdsa/der.py
@@ -180,7 +180,7 @@ def remove_integer(string):
     if not string:
         raise UnexpectedDER("Empty string is an invalid encoding of an "
                             "integer")
-    if not string.startswith(b("\x02")):
+    if string[:1] != b"\x02":
         n = string[0] if isinstance(string[0], integer_types) \
                 else ord(string[0])
         raise UnexpectedDER("wanted type 'integer' (0x02), got 0x%02x" % n)

--- a/src/ecdsa/der.py
+++ b/src/ecdsa/der.py
@@ -135,7 +135,7 @@ def remove_constructed(string):
 def remove_sequence(string):
     if not string:
         raise UnexpectedDER("Empty string does not encode a sequence")
-    if not string.startswith(b("\x30")):
+    if string[:1] != b"\x30":
         n = string[0] if isinstance(string[0], integer_types) else \
                 ord(string[0])
         raise UnexpectedDER("wanted type 'sequence' (0x30), got 0x%02x" % n)
@@ -157,7 +157,7 @@ def remove_octet_string(string):
 
 
 def remove_object(string):
-    if not string.startswith(b("\x06")):
+    if string[:1] != b"\x06":
         n = string[0] if isinstance(string[0], integer_types) else ord(string[0])
         raise UnexpectedDER("wanted type 'object' (0x06), got 0x%02x" % n)
     length, lengthlength = read_length(string[1:])
@@ -302,7 +302,7 @@ def remove_bitstring(string, expect_unused=_sentry):
                       " specified",
                       DeprecationWarning)
     num = string[0] if isinstance(string[0], integer_types) else ord(string[0])
-    if not string.startswith(b("\x03")):
+    if string[:1] != b"\x03":
         raise UnexpectedDER("wanted bitstring (0x03), got 0x%02x" % num)
     length, llen = read_length(string[1:])
     if not length:

--- a/src/ecdsa/der.py
+++ b/src/ecdsa/der.py
@@ -3,7 +3,8 @@ from __future__ import division
 import binascii
 import base64
 import warnings
-from six import int2byte, b, integer_types, text_type
+from six import int2byte, b, text_type
+from ._compat import str_idx_as_int
 
 
 class UnexpectedDER(Exception):
@@ -20,7 +21,7 @@ def encode_integer(r):
     if len(h) % 2:
         h = b("0") + h
     s = binascii.unhexlify(h)
-    num = s[0] if isinstance(s[0], integer_types) else ord(s[0])
+    num = str_idx_as_int(s, 0)
     if num <= 0x7f:
         return b("\x02") + int2byte(len(s)) + s
     else:
@@ -83,7 +84,7 @@ def encode_bitstring(s, unused=_sentry):
         if unused:
             if not s:
                 raise ValueError("unused is non-zero but s is empty")
-            last = s[-1] if isinstance(s[-1], integer_types) else ord(s[-1])
+            last = str_idx_as_int(s, -1)
             if last & (2 ** unused - 1):
                 raise ValueError("unused bits must be zeros in DER")
         encoded_unused = int2byte(unused)
@@ -121,7 +122,7 @@ def encode_number(n):
 
 
 def remove_constructed(string):
-    s0 = string[0] if isinstance(string[0], integer_types) else ord(string[0])
+    s0 = str_idx_as_int(string, 0)
     if (s0 & 0xe0) != 0xa0:
         raise UnexpectedDER("wanted type 'constructed tag' (0xa0-0xbf), "
                             "got 0x%02x" % s0)
@@ -136,8 +137,7 @@ def remove_sequence(string):
     if not string:
         raise UnexpectedDER("Empty string does not encode a sequence")
     if string[:1] != b"\x30":
-        n = string[0] if isinstance(string[0], integer_types) else \
-                ord(string[0])
+        n = str_idx_as_int(string, 0)
         raise UnexpectedDER("wanted type 'sequence' (0x30), got 0x%02x" % n)
     length, lengthlength = read_length(string[1:])
     if length > len(string) - 1 - lengthlength:
@@ -148,7 +148,7 @@ def remove_sequence(string):
 
 def remove_octet_string(string):
     if string[:1] != b"\x04":
-        n = string[0] if isinstance(string[0], integer_types) else ord(string[0])
+        n = str_idx_as_int(string, 0)
         raise UnexpectedDER("wanted type 'octetstring' (0x04), got 0x%02x" % n)
     length, llen = read_length(string[1:])
     body = string[1+llen:1+llen+length]
@@ -158,7 +158,7 @@ def remove_octet_string(string):
 
 def remove_object(string):
     if string[:1] != b"\x06":
-        n = string[0] if isinstance(string[0], integer_types) else ord(string[0])
+        n = str_idx_as_int(string, 0)
         raise UnexpectedDER("wanted type 'object' (0x06), got 0x%02x" % n)
     length, lengthlength = read_length(string[1:])
     body = string[1+lengthlength:1+lengthlength+length]
@@ -181,8 +181,7 @@ def remove_integer(string):
         raise UnexpectedDER("Empty string is an invalid encoding of an "
                             "integer")
     if string[:1] != b"\x02":
-        n = string[0] if isinstance(string[0], integer_types) \
-                else ord(string[0])
+        n = str_idx_as_int(string, 0)
         raise UnexpectedDER("wanted type 'integer' (0x02), got 0x%02x" % n)
     length, llen = read_length(string[1:])
     if length > len(string) - 1 - llen:
@@ -191,16 +190,14 @@ def remove_integer(string):
         raise UnexpectedDER("0-byte long encoding of integer")
     numberbytes = string[1+llen:1+llen+length]
     rest = string[1+llen+length:]
-    msb = numberbytes[0] if isinstance(numberbytes[0], integer_types) \
-            else ord(numberbytes[0])
+    msb = str_idx_as_int(numberbytes, 0)
     if not msb < 0x80:
         raise UnexpectedDER("Negative integers are not supported")
     # check if the encoding is the minimal one (DER requirement)
     if length > 1 and not msb:
         # leading zero byte is allowed if the integer would have been
         # considered a negative number otherwise
-        smsb = numberbytes[1] if isinstance(numberbytes[1], integer_types) \
-                else ord(numberbytes[1])
+        smsb = str_idx_as_int(numberbytes, 1)
         if smsb < 0x80:
             raise UnexpectedDER("Invalid encoding of integer, unnecessary "
                                 "zero padding bytes")
@@ -215,7 +212,7 @@ def read_number(string):
         if llen > len(string):
             raise UnexpectedDER("ran out of length bytes")
         number = number << 7
-        d = string[llen] if isinstance(string[llen], integer_types) else ord(string[llen])
+        d = str_idx_as_int(string, llen)
         number += (d & 0x7f)
         llen += 1
         if not d & 0x80:
@@ -238,7 +235,7 @@ def encode_length(l):
 def read_length(string):
     if not string:
         raise UnexpectedDER("Empty string can't encode valid length value")
-    num = string[0] if isinstance(string[0], integer_types) else ord(string[0])
+    num = str_idx_as_int(string, 0)
     if not (num & 0x80):
         # short form
         return (num & 0x7f), 1
@@ -250,7 +247,7 @@ def read_length(string):
     if llen > len(string)-1:
         raise UnexpectedDER("Length of length longer than provided buffer")
     # verify that the encoding is minimal possible (DER requirement)
-    msb = string[1] if isinstance(string[1], integer_types) else ord(string[1])
+    msb = str_idx_as_int(string, 1)
     if not msb or llen == 1 and msb < 0x80:
         raise UnexpectedDER("Not minimal encoding of length")
     return int(binascii.hexlify(string[1:1+llen]), 16), 1+llen
@@ -301,7 +298,7 @@ def remove_bitstring(string, expect_unused=_sentry):
         warnings.warn("Legacy call convention used, expect_unused= needs to be"
                       " specified",
                       DeprecationWarning)
-    num = string[0] if isinstance(string[0], integer_types) else ord(string[0])
+    num = str_idx_as_int(string, 0)
     if string[:1] != b"\x03":
         raise UnexpectedDER("wanted bitstring (0x03), got 0x%02x" % num)
     length, llen = read_length(string[1:])
@@ -310,8 +307,7 @@ def remove_bitstring(string, expect_unused=_sentry):
     body = string[1+llen:1+llen+length]
     rest = string[1+llen+length:]
     if expect_unused is not _sentry:
-        unused = body[0] if isinstance(body[0], integer_types) \
-            else ord(body[0])
+        unused = str_idx_as_int(body, 0)
         if not 0 <= unused <= 7:
             raise UnexpectedDER("Invalid encoding of unused bits")
         if expect_unused is not None and expect_unused != unused:
@@ -320,8 +316,7 @@ def remove_bitstring(string, expect_unused=_sentry):
         if unused:
             if not body:
                 raise UnexpectedDER("Invalid encoding of empty bit string")
-            last = body[-1] if isinstance(body[-1], integer_types) else \
-                ord(body[-1])
+            last = str_idx_as_int(body, -1)
             # verify that all the unused bits are set to zero (DER requirement)
             if last & (2 ** unused - 1):
                 raise UnexpectedDER("Non zero padding bits in bit string")

--- a/src/ecdsa/der.py
+++ b/src/ecdsa/der.py
@@ -147,7 +147,7 @@ def remove_sequence(string):
 
 
 def remove_octet_string(string):
-    if not string.startswith(b("\x04")):
+    if string[:1] != b"\x04":
         n = string[0] if isinstance(string[0], integer_types) else ord(string[0])
         raise UnexpectedDER("wanted type 'octetstring' (0x04), got 0x%02x" % n)
     length, llen = read_length(string[1:])

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -55,6 +55,15 @@ Primary classes for performing signing and verification operations.
         Abstract Syntax Notation 1 is a standard description language for
         specifying serialisation and deserialisation of data structures in a
         portable and cross-platform way.
+
+    bytes-like object
+        All the types that implement the buffer protocol. That includes
+        ``str`` (only on python2), ``bytes``, ``bytesarray``, ``array.array`
+        and ``memoryview`` of those objects.
+        Please note that ``array.array` serialisation (converting it to byte
+        string) is endianess dependant! Signature computed over ``array.array``
+        of integers on a big-endian system will not be verified on a
+        little-endian system and vice-versa.
 """
 
 import binascii
@@ -70,6 +79,7 @@ from .ecdsa import RSZeroError
 from .util import string_to_number, number_to_string, randrange
 from .util import sigencode_string, sigdecode_string
 from .util import oid_ecPublicKey, encoded_oid_ecPublicKey, MalformedSignature
+from ._compat import normalise_bytes
 
 
 __all__ = ["BadSignatureError", "BadDigestError", "VerifyingKey", "SigningKey",
@@ -231,8 +241,8 @@ class VerifyingKey(object):
         Python 2 days when there were no binary strings. In Python 3 the
         input needs to be a bytes-like object.
 
-        :param string: :term:`raw encoding` of the public key
-        :type string: bytes-like object
+        :param string: single point encoding of the public key
+        :type string: :term:`bytes-like object`
         :param curve: the curve on which the public key is expected to lie
         :type curve: ecdsa.curves.Curve
         :param hashfunc: The default hash function that will be used for
@@ -245,6 +255,7 @@ class VerifyingKey(object):
         :return: Initialised VerifyingKey object
         :rtype: VerifyingKey
         """
+        string = normalise_bytes(string)
         sig_len = len(string)
         if sig_len == curve.verifying_key_length:
             point = cls._from_raw_encoding(string, curve, validate_point)

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -830,6 +830,7 @@ class SigningKey(object):
         :return: Initialised VerifyingKey object
         :rtype: VerifyingKey
         """
+        string = normalise_bytes(string)
         s, empty = der.remove_sequence(string)
         if empty != b(""):
             raise der.UnexpectedDER("trailing junk after DER privkey: %s" %

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -328,16 +328,17 @@ class VerifyingKey(object):
         :return: Initialised VerifyingKey object
         :rtype: VerifyingKey
         """
+        string = normalise_bytes(string)
         # [[oid_ecPublicKey,oid_curve], point_str_bitstring]
         s1, empty = der.remove_sequence(string)
-        if empty != b(""):
+        if empty != b"":
             raise der.UnexpectedDER("trailing junk after DER pubkey: %s" %
                                     binascii.hexlify(empty))
         s2, point_str_bitstring = der.remove_sequence(s1)
         # s2 = oid_ecPublicKey,oid_curve
         oid_pk, rest = der.remove_object(s2)
         oid_curve, empty = der.remove_object(rest)
-        if empty != b(""):
+        if empty != b"":
             raise der.UnexpectedDER("trailing junk after DER pubkey objects: %s" %
                                     binascii.hexlify(empty))
         if not oid_pk == oid_ecPublicKey:
@@ -345,7 +346,7 @@ class VerifyingKey(object):
                                     "encoding: {0!r}".format(oid_pk))
         curve = find_curve(oid_curve)
         point_str, empty = der.remove_bitstring(point_str_bitstring, 0)
-        if empty != b(""):
+        if empty != b"":
             raise der.UnexpectedDER("trailing junk after pubkey pointstring: %s" %
                                     binascii.hexlify(empty))
         # raw encoding of point is invalid in DER files

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -737,6 +737,7 @@ class SigningKey(object):
         :return: Initialised SigningKey object
         :rtype: SigningKey
         """
+        string = normalise_bytes(string)
         if len(string) != curve.baselen:
             raise MalformedPointError(
                 "Invalid length of private key, received {0}, expected {1}"

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -974,6 +974,8 @@ class SigningKey(object):
         :rtype: bytes or sigencode function dependant type
         """
         hashfunc = hashfunc or self.default_hashfunc
+        data = normalise_bytes(data)
+        extra_entropy = normalise_bytes(extra_entropy)
         digest = hashfunc(data).digest()
 
         return self.sign_digest_deterministic(

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -543,7 +543,7 @@ class VerifyingKey(object):
         as the `sigdecode` parameter.
 
         :param signature: encoding of the signature
-        :type signature: bytes like object
+        :type signature: sigdecode method dependant
         :param data: data signed by the `signature`, will be hashed using
             `hashfunc`, if specified, or default hash function
         :type data: bytes like object
@@ -565,6 +565,10 @@ class VerifyingKey(object):
         :return: True if the verification was successful
         :rtype: bool
         """
+        # signature doesn't have to be a bytes-like-object so don't normalise
+        # it, the decoders will do that
+        data = normalise_bytes(data)
+
         hashfunc = hashfunc or self.default_hashfunc
         digest = hashfunc(data).digest()
         return self.verify_digest(signature, digest, sigdecode)
@@ -579,7 +583,7 @@ class VerifyingKey(object):
         as the `sigdecode` parameter.
 
         :param signature: encoding of the signature
-        :type signature: bytes like object
+        :type signature: sigdecode method dependant
         :param digest: raw hash value that the signature authenticates.
         :type digest: bytes like object
         :param sigdecode: Callable to define the way the signature needs to
@@ -597,6 +601,9 @@ class VerifyingKey(object):
         :return: True if the verification was successful
         :rtype: bool
         """
+        # signature doesn't have to be a bytes-like-object so don't normalise
+        # it, the decoders will do that
+        digest = normalise_bytes(digest)
         if len(digest) > self.curve.baselen:
             raise BadDigestError("this curve (%s) is too short "
                                  "for your digest (%d)" % (self.curve.name,

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -1123,6 +1123,7 @@ class SigningKey(object):
         :return: encoded signature for the `digest` hash
         :rtype: bytes or sigencode function dependant type
         """
+        digest = normalise_bytes(digest)
         if len(digest) > self.curve.baselen:
             raise BadDigestError("this curve (%s) is too short "
                                  "for your digest (%d)" % (self.curve.name,

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -383,6 +383,7 @@ class VerifyingKey(object):
         :return: Initialised VerifyingKey objects
         :rtype: list of VerifyingKey
         """
+        data = normalise_bytes(data)
         digest = hashfunc(data).digest()
         return cls.from_public_key_recovery_with_digest(
             signature, digest, curve, hashfunc=hashfunc,
@@ -423,6 +424,7 @@ class VerifyingKey(object):
         r, s = sigdecode(signature, generator.order())
         sig = ecdsa.Signature(r, s)
 
+        digest = normalise_bytes(digest)
         digest_as_number = string_to_number(digest)
         pks = sig.recover_public_keys(digest_as_number, generator)
 

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -1018,6 +1018,7 @@ class SigningKey(object):
         :rtype: bytes or sigencode function dependant type
         """
         secexp = self.privkey.secret_multiplier
+        hashfunc = hashfunc or self.default_hashfunc
 
         def simple_r_s(r, s, order):
             return r, s, order

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -1084,6 +1084,7 @@ class SigningKey(object):
         :rtype: bytes or sigencode function dependant type
         """
         hashfunc = hashfunc or self.default_hashfunc
+        data = normalise_bytes(data)
         h = hashfunc(data).digest()
         return self.sign_digest(h, entropy, sigencode, k)
 

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -1019,6 +1019,8 @@ class SigningKey(object):
         """
         secexp = self.privkey.secret_multiplier
         hashfunc = hashfunc or self.default_hashfunc
+        digest = normalise_bytes(digest)
+        extra_entropy = normalise_bytes(extra_entropy)
 
         def simple_r_s(r, s, order):
             return r, s, order

--- a/src/ecdsa/test_der.py
+++ b/src/ecdsa/test_der.py
@@ -10,6 +10,8 @@ from .der import remove_integer, UnexpectedDER, read_length, encode_bitstring,\
 from six import b
 import pytest
 import warnings
+from ._compat import str_idx_as_int
+
 
 class TestRemoveInteger(unittest.TestCase):
     # DER requires the integers to be 0-padded only if they would be
@@ -229,3 +231,14 @@ class TestRemoveBitstring(unittest.TestCase):
     def test_invalid_padding_bits(self):
         with self.assertRaises(UnexpectedDER):
             remove_bitstring(b'\x03\x02\x01\xff', None)
+
+
+class TestStrIdxAsInt(unittest.TestCase):
+    def test_str(self):
+        self.assertEqual(115, str_idx_as_int('str', 0))
+
+    def test_bytes(self):
+        self.assertEqual(115, str_idx_as_int(b'str', 0))
+
+    def test_bytearray(self):
+        self.assertEqual(115, str_idx_as_int(bytearray(b'str'), 0))

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -223,3 +223,32 @@ def test_VerifyingKey_verify(
     sig = mod_apply(signature)
 
     assert vrf_mthd(sig, fun(vrf_data), sigdecode=decoder)
+
+
+# test SigningKey.from_string()
+prv_key_bytes = (b'^\xc8B\x0b\xd6\xef\x92R\xa9B\xe9\x89\x04<\xa2'
+                 b'\x9fV\x1f\xa5%w\x0e\xb1\xc5')
+assert len(prv_key_bytes) == 24
+keys = []
+for modifier, convert in [
+        ("bytes", lambda x: x),
+        ("bytes memoryview", buffer),
+        ("bytearray", bytearray),
+        ("bytearray memoryview", lambda x: buffer(bytearray(x))),
+        ("array.array of bytes", lambda x: array.array('B', x)),
+        ("array.array of bytes memoryview",
+         lambda x: buffer(array.array('B', x))),
+        ("array.array of ints", lambda x: array.array('I', x)),
+        ("array.array of ints memoryview",
+         lambda x: buffer(array.array('I', x)))
+        ]:
+    keys.append(pytest.param(
+        convert,
+        id=modifier))
+
+@pytest.mark.parametrize("convert", keys)
+def test_SigningKey_from_string(convert):
+    key = convert(prv_key_bytes)
+    sk = SigningKey.from_string(key)
+
+    assert sk.to_string() == prv_key_bytes

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -178,7 +178,7 @@ assert len(data) % 4 == 0
 sha1 = hashlib.sha1()
 sha1.update(data)
 data_hash = sha1.digest()
-
+assert isinstance(data_hash, bytes)
 sig_raw = sk.sign(data, sigencode=sigencode_string)
 assert isinstance(sig_raw, bytes)
 sig_der = sk.sign(data, sigencode=sigencode_der)
@@ -272,3 +272,15 @@ def test_SigningKey_from_der(convert):
     sk = SigningKey.from_der(key)
 
     assert sk.to_string() == prv_key_bytes
+
+
+# test SigningKey.sign_deterministic()
+extra_entropy=b'\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11'
+
+@pytest.mark.parametrize("convert", converters)
+def test_SigningKey_sign_deterministic(convert):
+    sig = sk.sign_deterministic(
+        convert(data),
+        extra_entropy=convert(extra_entropy))
+
+    vk.verify(sig, data)

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -77,3 +77,23 @@ class TestVerifyingKeyFromString(unittest.TestCase):
         vk = VerifyingKey.from_string(buffer(arr))
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_bytes_uncompressed(self):
+        vk = VerifyingKey.from_string(b'\x04' + self.key_bytes)
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_bytearray_uncompressed(self):
+        vk = VerifyingKey.from_string(bytearray(b'\x04' + self.key_bytes))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_bytes_compressed(self):
+        vk = VerifyingKey.from_string(b'\x02' + self.key_bytes[:24])
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_bytearray_uncompressed(self):
+        vk = VerifyingKey.from_string(bytearray(b'\x02' + self.key_bytes[:24]))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -284,3 +284,13 @@ def test_SigningKey_sign_deterministic(convert):
         extra_entropy=convert(extra_entropy))
 
     vk.verify(sig, data)
+
+
+# test SigningKey.sign_digest_deterministic()
+@pytest.mark.parametrize("convert", converters)
+def test_SigningKey_sign_digest_deterministic(convert):
+    sig = sk.sign_digest_deterministic(
+        convert(data_hash),
+        extra_entropy=convert(extra_entropy))
+
+    vk.verify(sig, data)

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -1,0 +1,97 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+try:
+    buffer
+except NameError:
+    buffer = memoryview
+
+import array
+import six
+import sys
+import pytest
+
+from .keys import VerifyingKey
+
+
+class TestVerifyingKeyFromString(unittest.TestCase):
+    """
+    Verify that ecdsa.keys.VerifyingKey.from_string() can be used with
+    bytes-like objects
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.key_bytes = (b'\x04L\xa2\x95\xdb\xc7Z\xd7\x1f\x93\nz\xcf\x97\xcf'
+                       b'\xd7\xc2\xd9o\xfe8}X!\xae\xd4\xfah\xfa^\rpI\xba\xd1'
+                       b'Y\xfb\x92xa\xebo+\x9cG\xfav\xca')
+        cls.vk = VerifyingKey.from_string(cls.key_bytes)
+
+    def test_bytes(self):
+        self.assertIsNotNone(self.vk)
+        self.assertIsInstance(self.vk, VerifyingKey)
+        self.assertEqual(
+            self.vk.pubkey.point.x(),
+            105419898848891948935835657980914000059957975659675736097)
+        self.assertEqual(
+            self.vk.pubkey.point.y(),
+            4286866841217412202667522375431381222214611213481632495306)
+
+    def test_bytes_memoryview(self):
+        vk = VerifyingKey.from_string(buffer(self.key_bytes))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    @unittest.skipIf(sys.version_info >= (2, 7), "fails on python2.6 only")
+    @unittest.expectedFailure
+    def test_bytearray26(self):
+        vk = VerifyingKey.from_string(bytearray(self.key_bytes))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    @unittest.skipUnless(sys.version_info >= (2, 7), "fails on python2.6 only")
+    def test_bytearray(self):
+        vk = VerifyingKey.from_string(bytearray(self.key_bytes))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_bytesarray_memoryview(self):
+        vk = VerifyingKey.from_string(buffer(bytearray(self.key_bytes)))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_array_array_of_bytes(self):
+        arr = array.array('B', self.key_bytes)
+        vk = VerifyingKey.from_string(arr)
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_array_array_of_bytes_memoryview(self):
+        arr = array.array('B', self.key_bytes)
+        vk = VerifyingKey.from_string(buffer(arr))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    @unittest.expectedFailure
+    def test_array_array_of_ints(self):
+        arr = array.array('I', self.key_bytes)
+        vk = VerifyingKey.from_string(arr)
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    @unittest.skipIf(sys.version_info >= (3, 0), "Fails on python3")
+    def test_array_array_of_ints_memoryview2(self):
+        arr = array.array('I', self.key_bytes)
+        vk = VerifyingKey.from_string(buffer(arr))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    @unittest.expectedFailure
+    @unittest.skipUnless(sys.version_info >= (3, 0), "Fails on python3")
+    def test_array_array_of_ints_memoryview(self):
+        arr = array.array('I', self.key_bytes)
+        vk = VerifyingKey.from_string(buffer(arr))
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -294,3 +294,10 @@ def test_SigningKey_sign_digest_deterministic(convert):
         extra_entropy=convert(extra_entropy))
 
     vk.verify(sig, data)
+
+
+@pytest.mark.parametrize("convert", converters)
+def test_SigningKey_sign(convert):
+    sig = sk.sign(convert(data))
+
+    vk.verify(sig, data)

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -301,3 +301,10 @@ def test_SigningKey_sign(convert):
     sig = sk.sign(convert(data))
 
     vk.verify(sig, data)
+
+
+@pytest.mark.parametrize("convert", converters)
+def test_SigningKey_sign_digest(convert):
+    sig = sk.sign_digest(convert(data_hash))
+
+    vk.verify(sig, data)

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -44,14 +44,6 @@ class TestVerifyingKeyFromString(unittest.TestCase):
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
 
-    @unittest.skipIf(sys.version_info >= (2, 7), "fails on python2.6 only")
-    @unittest.expectedFailure
-    def test_bytearray26(self):
-        vk = VerifyingKey.from_string(bytearray(self.key_bytes))
-
-        self.assertEqual(self.vk.to_string(), vk.to_string())
-
-    @unittest.skipUnless(sys.version_info >= (2, 7), "fails on python2.6 only")
     def test_bytearray(self):
         vk = VerifyingKey.from_string(bytearray(self.key_bytes))
 
@@ -74,22 +66,12 @@ class TestVerifyingKeyFromString(unittest.TestCase):
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
 
-    @unittest.expectedFailure
     def test_array_array_of_ints(self):
         arr = array.array('I', self.key_bytes)
         vk = VerifyingKey.from_string(arr)
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
 
-    @unittest.skipIf(sys.version_info >= (3, 0), "Fails on python3")
-    def test_array_array_of_ints_memoryview2(self):
-        arr = array.array('I', self.key_bytes)
-        vk = VerifyingKey.from_string(buffer(arr))
-
-        self.assertEqual(self.vk.to_string(), vk.to_string())
-
-    @unittest.expectedFailure
-    @unittest.skipUnless(sys.version_info >= (3, 0), "Fails on python3")
     def test_array_array_of_ints_memoryview(self):
         arr = array.array('I', self.key_bytes)
         vk = VerifyingKey.from_string(buffer(arr))

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -127,7 +127,6 @@ class TestVerifyingKeyFromDer(unittest.TestCase):
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
 
-    @unittest.expectedFailure
     def test_bytes_memoryview(self):
         vk = VerifyingKey.from_der(buffer(self.key_bytes))
 
@@ -138,15 +137,19 @@ class TestVerifyingKeyFromDer(unittest.TestCase):
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
 
-    @unittest.expectedFailure
     def test_bytesarray_memoryview(self):
         vk = VerifyingKey.from_der(buffer(bytearray(self.key_bytes)))
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
 
-    @unittest.expectedFailure
     def test_array_array_of_bytes(self):
         arr = array.array('B', self.key_bytes)
         vk = VerifyingKey.from_der(arr)
+
+        self.assertEqual(self.vk.to_string(), vk.to_string())
+
+    def test_array_array_of_bytes_memoryview(self):
+        arr = array.array('B', self.key_bytes)
+        vk = VerifyingKey.from_der(buffer(arr))
 
         self.assertEqual(self.vk.to_string(), vk.to_string())

--- a/src/ecdsa/util.py
+++ b/src/ecdsa/util.py
@@ -6,6 +6,7 @@ import binascii
 from hashlib import sha256
 from six import PY3, int2byte, b, next
 from . import der
+from ._compat import normalise_bytes
 
 # RFC5480:
 #   The "unrestricted" algorithm identifier is:
@@ -312,6 +313,7 @@ def sigdecode_string(signature, order):
     :return: tuple with decoded 'r' and 's' values of signature
     :rtype: tuple of ints
     """
+    signature = normalise_bytes(signature)
     l = orderlen(order)
     if not len(signature) == 2 * l:
         raise MalformedSignature(
@@ -347,6 +349,8 @@ def sigdecode_strings(rs_strings, order):
             "Invalid number of strings provided: {0}, expected 2"
             .format(len(rs_strings)))
     (r_str, s_str) = rs_strings
+    r_str = normalise_bytes(r_str)
+    s_str = normalise_bytes(s_str)
     l = orderlen(order)
     if not len(r_str) == l:
         raise MalformedSignature(
@@ -388,14 +392,15 @@ def sigdecode_der(sig_der, order):
     :return: tuple with decoded 'r' and 's' values of signature
     :rtype: tuple of ints
     """
+    sig_der = normalise_bytes(sig_der)
     # return der.encode_sequence(der.encode_integer(r), der.encode_integer(s))
     rs_strings, empty = der.remove_sequence(sig_der)
-    if empty != b(""):
+    if empty != b"":
         raise der.UnexpectedDER("trailing junk after DER sig: %s" %
                                 binascii.hexlify(empty))
     r, rest = der.remove_integer(rs_strings)
     s, empty = der.remove_integer(rest)
-    if empty != b(""):
+    if empty != b"":
         raise der.UnexpectedDER("trailing junk after DER numbers: %s" %
                                 binascii.hexlify(empty))
     return r, s


### PR DESCRIPTION
Test for and fix the bugs in handling bytes-like objects in `VerifyingKey` and `SigningKey`.

fixes #135 
fixes #144