### PR TITLE
support for setting hashfunc on verifying key load

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -139,7 +139,7 @@ class VerifyingKey(object):
         pub_key = self.to_string("compressed")
         return "VerifyingKey.from_string({0!r}, {1!r}, {2})".format(
             pub_key, self.curve, self.default_hashfunc().name)
-        
+
     def __eq__(self, other):
         """Return True if the points are identical, False otherwise."""
         if isinstance(other, VerifyingKey):  
@@ -306,7 +306,7 @@ class VerifyingKey(object):
                                      validate_point)
 
     @classmethod
-    def from_pem(cls, string):
+    def from_pem(cls, string, hashfunc=sha1):
         """
         Initialise from public key stored in :term:`PEM` format.
 
@@ -324,10 +324,10 @@ class VerifyingKey(object):
         :return: Initialised VerifyingKey object
         :rtype: VerifyingKey
         """
-        return cls.from_der(der.unpem(string))
+        return cls.from_der(der.unpem(string), hashfunc=hashfunc)
 
     @classmethod
-    def from_der(cls, string):
+    def from_der(cls, string, hashfunc=sha1):
         """
         Initialise the key stored in :term:`DER` format.
 
@@ -380,7 +380,7 @@ class VerifyingKey(object):
         # raw encoding of point is invalid in DER files
         if len(point_str) == curve.verifying_key_length:
             raise der.UnexpectedDER("Malformed encoding of public point")
-        return cls.from_string(point_str, curve)
+        return cls.from_string(point_str, curve, hashfunc=hashfunc)
 
     @classmethod
     def from_public_key_recovery(cls, signature, data, curve, hashfunc=sha1,

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -120,13 +120,14 @@ class TestVerifyingKeyFromDer(unittest.TestCase):
             "-----BEGIN PUBLIC KEY-----\n"
             "MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEuIF30ITvF/XkVjlAgCg2D59ZtKTX\n"
             "Jk5i2gZR3OR6NaTFtFz1FZNCOotVe5wgmfNs\n"
-            "-----END PUBLIC KEY-----\n")       
-        
+            "-----END PUBLIC KEY-----\n")
+        cls.key_pem = key_str
+
         cls.key_bytes = unpem(key_str)
         assert isinstance(cls.key_bytes, bytes)
         cls.vk = VerifyingKey.from_pem(key_str)
         cls.sk = SigningKey.from_pem(prv_key_str)
-        
+
         key_str = (
             "-----BEGIN PUBLIC KEY-----\n"
             "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4H3iRbG4TSrsSRb/gusPQB/4YcN8\n"
@@ -134,6 +135,16 @@ class TestVerifyingKeyFromDer(unittest.TestCase):
             "-----END PUBLIC KEY-----\n"
         )
         cls.vk2 = VerifyingKey.from_pem(key_str)
+
+    def test_custom_hashfunc(self):
+        vk = VerifyingKey.from_der(self.key_bytes, hashlib.sha256)
+
+        self.assertIs(vk.default_hashfunc, hashlib.sha256)
+
+    def test_from_pem_with_custom_hashfunc(self):
+        vk = VerifyingKey.from_pem(self.key_pem, hashlib.sha256)
+
+        self.assertIs(vk.default_hashfunc, hashlib.sha256)
 
     def test_bytes(self):
         vk = VerifyingKey.from_der(self.key_bytes)
@@ -166,14 +177,14 @@ class TestVerifyingKeyFromDer(unittest.TestCase):
         vk = VerifyingKey.from_der(buffer(arr))
 
         self.assertEqual(self.vk.to_string(), vk.to_string())
-        
-    def test_equality_on_verifying_keys(self):     
+
+    def test_equality_on_verifying_keys(self):
         self.assertEqual(self.vk, self.sk.get_verifying_key())
-        
-    def test_inequality_on_verifying_keys(self):     
+
+    def test_inequality_on_verifying_keys(self):
         self.assertNotEqual(self.vk, self.vk2)
-        
-    def test_inequality_on_verifying_keys_not_implemented(self):     
+
+    def test_inequality_on_verifying_keys_not_implemented(self):
         self.assertNotEqual(self.vk, None)
 
 


### PR DESCRIPTION
All the other methods for creating the keys (both Signing and Verifying)
allow setting the default_hashfunc, add the parameter to the last
two of them

also a bit of whitespace cleanup

fixes #72 