### PR TITLE
Fix for Python 3.10, 4 and 10

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -68,7 +68,7 @@ Primary classes for performing signing and verification operations.
 
 import binascii
 from hashlib import sha1
-from six import PY3, b
+from six import PY2, b
 from . import ecdsa
 from . import der
 from . import rfc6979
@@ -823,7 +823,7 @@ class SigningKey(object):
         """
         # the privkey pem may have multiple sections, commonly it also has
         # "EC PARAMETERS", we need just "EC PRIVATE KEY".
-        if PY3 and isinstance(string, str):
+        if not PY2 and isinstance(string, str):
             string = string.encode()
         privkey_pem = string[string.index(b("-----BEGIN EC PRIVATE KEY-----")):]
         return cls.from_der(der.unpem(privkey_pem), hashfunc)

--- a/src/ecdsa/numbertheory.py
+++ b/src/ecdsa/numbertheory.py
@@ -11,7 +11,7 @@
 
 from __future__ import division
 
-from six import integer_types, PY3
+from six import integer_types, PY2
 from six.moves import reduce
 try:
     xrange
@@ -198,11 +198,11 @@ def square_root_mod_prime(a, p):
       return (2 * a * pow(4 * a, (p - 5) // 8, p)) % p
     raise RuntimeError("Shouldn't get here.")
 
-  if PY3:
-    range_top = p
-  else:
+  if PY2:
     # xrange on python2 can take integers representable as C long only
     range_top = min(0x7fffffff, p)
+  else:
+      range_top = p
   for b in xrange(2, range_top):
     if jacobi(b * b - 4 * a, p) == -1:
       f = (a, -b, 1)

--- a/src/ecdsa/util.py
+++ b/src/ecdsa/util.py
@@ -5,7 +5,7 @@ import math
 import binascii
 import sys
 from hashlib import sha256
-from six import PY3, int2byte, b, next
+from six import PY2, int2byte, b, next
 from . import der
 from ._compat import normalise_bytes
 
@@ -76,10 +76,10 @@ class PRNG:
     def __call__(self, numbytes):
         a = [next(self.generator) for i in range(numbytes)]
 
-        if PY3:
-            return bytes(a)
-        else:
+        if PY2:
             return "".join(a)
+        else:
+            return bytes(a)
 
     def block_generator(self, seed):
         counter = 0

--- a/src/ecdsa/util.py
+++ b/src/ecdsa/util.py
@@ -17,7 +17,7 @@ from ._compat import normalise_bytes
 oid_ecPublicKey = (1, 2, 840, 10045, 2, 1)
 encoded_oid_ecPublicKey = der.encode_oid(*oid_ecPublicKey)
 
-if sys.version > '3':
+if sys.version_info >= (3,):
     def entropy_to_bits(ent_256):
         """Convert a bytestring to string of 0's and 1's"""
         return bin(int.from_bytes(ent_256, 'big'))[2:].zfill(len(ent_256)*8)
@@ -27,7 +27,7 @@ else:
         return ''.join(bin(ord(x))[2:].zfill(8) for x in ent_256)
 
 
-if sys.version < '2.7':
+if sys.version_info < (2, 7):
     # Can't add a method to a built-in type so we are stuck with this
     def bit_length(x):
         return len(bin(x)) - 2


### PR DESCRIPTION
It's generally safer to compare to the `sys.version_info` tuple than the `sys.version` string, which can include assumptions that each version component is always a single character.

---

There's also some code which uses `six.PY3`, similar to:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print "Python 2 code" 
```

Where:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code!

Instead, use `six.PY2`.

---

Found with https://github.com/asottile/flake8-2020.
