### PR TITLE
Expose allow_truncate option in SigningKey.sign() and VerifyingKey.verify()

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -602,8 +602,12 @@ class VerifyingKey(object):
         )
 
     def verify(
-        self, signature, data, hashfunc=None, sigdecode=sigdecode_string,
-        allow_truncate=True
+        self,
+        signature,
+        data,
+        hashfunc=None,
+        sigdecode=sigdecode_string,
+        allow_truncate=True,
     ):
         """
         Verify a signature made over provided data.

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -602,7 +602,8 @@ class VerifyingKey(object):
         )
 
     def verify(
-        self, signature, data, hashfunc=None, sigdecode=sigdecode_string
+        self, signature, data, hashfunc=None, sigdecode=sigdecode_string,
+        allow_truncate=True
     ):
         """
         Verify a signature made over provided data.
@@ -629,6 +630,11 @@ class VerifyingKey(object):
             second one. See :func:`ecdsa.util.sigdecode_string` and
             :func:`ecdsa.util.sigdecode_der` for examples.
         :type sigdecode: callable
+        :param bool allow_truncate: if True, the provided digest can have
+            bigger bit-size than the order of the curve, the extra bits (at
+            the end of the digest) will be truncated. Use it when verifying
+            SHA-384 output using NIST256p or in similar situations. Defaults to
+            True.
 
         :raises BadSignatureError: if the signature is invalid or malformed
 
@@ -641,7 +647,7 @@ class VerifyingKey(object):
 
         hashfunc = hashfunc or self.default_hashfunc
         digest = hashfunc(data).digest()
-        return self.verify_digest(signature, digest, sigdecode, True)
+        return self.verify_digest(signature, digest, sigdecode, allow_truncate)
 
     def verify_digest(
         self,
@@ -1262,6 +1268,7 @@ class SigningKey(object):
         hashfunc=None,
         sigencode=sigencode_string,
         k=None,
+        allow_truncate=True,
     ):
         """
         Create signature over data using the probabilistic ECDSA algorithm.
@@ -1298,6 +1305,11 @@ class SigningKey(object):
         :param int k: a pre-selected nonce for calculating the signature.
             In typical use cases, it should be set to None (the default) to
             allow its generation from an entropy source.
+        :param bool allow_truncate: if True, the provided digest can have
+            bigger bit-size than the order of the curve, the extra bits (at
+            the end of the digest) will be truncated. Use it when signing
+            SHA-384 output using NIST256p or in similar situations. True by
+            default.
 
         :raises RSZeroError: in the unlikely event when "r" parameter or
             "s" parameter is equal 0 as that would leak the key. Calee should
@@ -1309,7 +1321,7 @@ class SigningKey(object):
         hashfunc = hashfunc or self.default_hashfunc
         data = normalise_bytes(data)
         h = hashfunc(data).digest()
-        return self.sign_digest(h, entropy, sigencode, k, allow_truncate=True)
+        return self.sign_digest(h, entropy, sigencode, k, allow_truncate)
 
     def sign_digest(
         self,

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -1204,6 +1204,11 @@ class OpenSSL(unittest.TestCase):
 
 
 class TooSmallCurve(unittest.TestCase):
+    OPENSSL_SUPPORTED_CURVES = set(
+        c.split(":")[0].strip()
+        for c in run_openssl("ecparam -list_curves").split("\n")
+    )
+
     @pytest.mark.skipif("prime192v1" not in OPENSSL_SUPPORTED_CURVES,
                         reason="system openssl does not support prime192v1")
     def test_sign_too_small_curve_dont_allow_truncate_raises(self):

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -1210,7 +1210,7 @@ class TooSmallCurve(unittest.TestCase):
         sk = SigningKey.generate(curve=NIST192p)
         vk = sk.get_verifying_key()
         data = b("data")
-        with self.assertRaises(ecdsa.keys.BadDigestError):
+        with self.assertRaises(BadDigestError):
             sk.sign(
                 data,
                 hashfunc=partial(hashlib.new, "SHA256"),

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -1203,6 +1203,44 @@ class OpenSSL(unittest.TestCase):
         )
 
 
+class TooSmallCurve(unittest.TestCase):
+    @pytest.mark.skipif("prime192v1" not in OPENSSL_SUPPORTED_CURVES,
+                        reason="system openssl does not support prime192v1")
+    def test_sign_too_small_curve_dont_allow_truncate_raises(self):
+        sk = SigningKey.generate(curve=NIST192p)
+        vk = sk.get_verifying_key()
+        data = b("data")
+        with self.assertRaises(ecdsa.keys.BadDigestError):
+            sk.sign(
+                data,
+                hashfunc=partial(hashlib.new, "SHA256"),
+                sigencode=sigencode_der,
+                allow_truncate=False,
+            )
+
+    @pytest.mark.skipif("prime192v1" not in OPENSSL_SUPPORTED_CURVES,
+                        reason="system openssl does not support prime192v1")
+    def test_verify_too_small_curve_dont_allow_truncate_raises(self):
+        sk = SigningKey.generate(curve=NIST192p)
+        vk = sk.get_verifying_key()
+        data = b("data")
+        sig_der = sk.sign(
+            data,
+            hashfunc=partial(hashlib.new, "SHA256"),
+            sigencode=sigencode_der,
+            allow_truncate=True,
+        )
+        with self.assertRaises(BadDigestError):
+            vk.verify(
+                sig_der,
+                data,
+                hashfunc=partial(hashlib.new, "SHA256"),
+                sigdecode=sigdecode_der,
+                allow_truncate=False,
+            )
+
+
+
 class DER(unittest.TestCase):
     def test_integer(self):
         self.assertEqual(der.encode_integer(0), b("\x02\x01\x00"))

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -1209,8 +1209,10 @@ class TooSmallCurve(unittest.TestCase):
         for c in run_openssl("ecparam -list_curves").split("\n")
     )
 
-    @pytest.mark.skipif("prime192v1" not in OPENSSL_SUPPORTED_CURVES,
-                        reason="system openssl does not support prime192v1")
+    @pytest.mark.skipif(
+        "prime192v1" not in OPENSSL_SUPPORTED_CURVES,
+        reason="system openssl does not support prime192v1",
+    )
     def test_sign_too_small_curve_dont_allow_truncate_raises(self):
         sk = SigningKey.generate(curve=NIST192p)
         vk = sk.get_verifying_key()
@@ -1223,8 +1225,10 @@ class TooSmallCurve(unittest.TestCase):
                 allow_truncate=False,
             )
 
-    @pytest.mark.skipif("prime192v1" not in OPENSSL_SUPPORTED_CURVES,
-                        reason="system openssl does not support prime192v1")
+    @pytest.mark.skipif(
+        "prime192v1" not in OPENSSL_SUPPORTED_CURVES,
+        reason="system openssl does not support prime192v1",
+    )
     def test_verify_too_small_curve_dont_allow_truncate_raises(self):
         sk = SigningKey.generate(curve=NIST192p)
         vk = sk.get_verifying_key()
@@ -1243,7 +1247,6 @@ class TooSmallCurve(unittest.TestCase):
                 sigdecode=sigdecode_der,
                 allow_truncate=False,
             )
-
 
 
 class DER(unittest.TestCase):


### PR DESCRIPTION
PR #168 added the `allow_truncate` option to `SigningKey.sign_digest()` and `VerifyingKey.verify_digest()`, and then forcibly defaulted their value to `True` in [`SigningKey.sign()`](https://github.com/warner/python-ecdsa/pull/168/files#diff-a6539daf3a35718bc7cb90c1395b6953R1138) and [`VerifyingKey.verify()`](https://github.com/warner/python-ecdsa/pull/168/files#diff-a6539daf3a35718bc7cb90c1395b6953R602):

```python
class VerifyingKey(object):
    ...
    def verify(self, signature, data, hashfunc=None,
               sigdecode=sigdecode_string):
        ...
        return self.verify_digest(signature, digest, sigdecode, True)
```

```python
class SigningKey(object):
    def sign(self, data, entropy=None, hashfunc=None,
             sigencode=sigencode_string, k=None):
        return self.sign_digest(h, entropy, sigencode, k, allow_truncate=True)
```

Unfortunately, this didn't actually satisfy the request in #129 (emphasis mine):

> Add an option to **verify()** and **sign()** methods to change if they will accept bigger inputs and appropriately truncate them.

Note that while #168 added the `allow_truncate` option for `VerifyingKey.verify_digest()` and `SigningKey.sign_digest()`, the option is still not exposed in the signatures for `VerifyingKey.verify()` `SigningKey.sign()`.

Furthermore, due to the default behavior changing, `ecdsa` version 0.15 breaks tests for downstream projects: mpdavis/python-jose#176, which tested for the old behavior (eg: `allow_truncate=False`).

This PR routes the `allow_truncate` option up to `VerifyingKey.verify_digest()` and `SigningKey.sign_digest()`, and more importantly for you, keeps the default value to `True`. This is to avoid possibly re-disrupting `ecdsa` users but also allows `python-jose` and other users to opt-in to the previous behavior.

I also added tests for the new options.