### PR TITLE
add option to lazily precompute multiplication tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ t/
 # Backup files
 *.swp
 *~
+.idea
+.cache

--- a/src/ecdsa/__init__.py
+++ b/src/ecdsa/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "numbertheory",
     "test_pyecdsa",
     "util",
+    "six",
 ]
 
 _hush_pyflakes = [
@@ -73,4 +74,3 @@ _hush_pyflakes = [
     BRAINPOOLP512r1,
 ]
 del _hush_pyflakes
-

--- a/src/ecdsa/__init__.py
+++ b/src/ecdsa/__init__.py
@@ -1,3 +1,10 @@
+import os
+
+# when enabled, multiplication tables are precomputed only when actually needed:
+# that is, the specific curve is actually first used in user code. otherwise, multiplication
+# tables for _all_ curves supported are precomputed at library _import_ time effectively
+ENABLE_LAZY_PRECOMPUTE = os.environ.get('PYTHON_ECDSA_ENABLE_LAZY_PRECOMPUTE', None) is not None
+
 from .keys import (
     SigningKey,
     VerifyingKey,
@@ -44,7 +51,6 @@ __all__ = [
     "numbertheory",
     "test_pyecdsa",
     "util",
-    "six",
 ]
 
 _hush_pyflakes = [
@@ -74,3 +80,4 @@ _hush_pyflakes = [
     BRAINPOOLP512r1,
 ]
 del _hush_pyflakes
+

--- a/src/ecdsa/__init__.py
+++ b/src/ecdsa/__init__.py
@@ -1,10 +1,3 @@
-import os
-
-# when enabled, multiplication tables are precomputed only when actually needed:
-# that is, the specific curve is actually first used in user code. otherwise, multiplication
-# tables for _all_ curves supported are precomputed at library _import_ time effectively
-ENABLE_LAZY_PRECOMPUTE = os.environ.get('PYTHON_ECDSA_ENABLE_LAZY_PRECOMPUTE', None) is not None
-
 from .keys import (
     SigningKey,
     VerifyingKey,

--- a/src/ecdsa/ellipticcurve.py
+++ b/src/ecdsa/ellipticcurve.py
@@ -34,7 +34,6 @@
 # Written in 2005 by Peter Pearson and placed in the public domain.
 
 from __future__ import division
-import os
 
 try:
     from gmpy2 import mpz
@@ -181,7 +180,7 @@ class PointJacobi(object):
     def _maybe_precompute(self):
         if self.__generator:
             # since we lack promotion of read-locks to write-locks, we do a
-            # "acquire-read-lock check, acquire-write-lock plus recheck" cycle ..
+            # "acquire-read-lock check, acquire-write-lock plus recheck" cycle
             try:
                 self._scale_lock.reader_acquire()
                 if self.__precompute:
@@ -197,7 +196,9 @@ class PointJacobi(object):
                 assert order
                 i = 1
                 order *= 2
-                doubler = PointJacobi(self.__curve, self.__x, self.__y, self.__z, order)
+                doubler = PointJacobi(
+                    self.__curve, self.__x, self.__y, self.__z, order
+                )
                 order *= 2
                 self.__precompute.append((doubler.x(), doubler.y()))
 

--- a/src/ecdsa/ellipticcurve.py
+++ b/src/ecdsa/ellipticcurve.py
@@ -34,6 +34,7 @@
 # Written in 2005 by Peter Pearson and placed in the public domain.
 
 from __future__ import division
+import os
 
 try:
     from gmpy2 import mpz
@@ -177,10 +178,11 @@ class PointJacobi(object):
         self.__generator = generator
         self.__precompute = []
 
-        # unless ENABLE_LAZY_PRECOMPUTE is enabled, precompute multiplication
-        # tables _now_ (at ctor/import time)
-        import ecdsa
-        if not ecdsa.ENABLE_LAZY_PRECOMPUTE:
+        # when enabled, multiplication tables are precomputed only when actually needed:
+        # that is, the specific curve is actually first used in user code. otherwise, multiplication
+        # tables for _all_ curves supported are precomputed at library _import_ time effectively
+        ENABLE_LAZY_PRECOMPUTE = os.environ.get('PYTHON_ECDSA_ENABLE_LAZY_PRECOMPUTE', None) is not None
+        if not ENABLE_LAZY_PRECOMPUTE:
             self._maybe_precompute()
 
     def _maybe_precompute(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, py37, py38, py, pypy, pypy3, gmpy2py27, gmpy2py38, gmpypy27, gmpypy38
+envlist = py26, py27, py33, py34, py35, py36, py37, py38, py, pypy, pypy3, gmpy2py27, gmpy2py38, gmpypy27, gmpypy38, codechecks
 
 [testenv]
 deps =


### PR DESCRIPTION
this is an attempt to fix https://github.com/warner/python-ecdsa/issues/180

the does not change any existing behavior, but adds new behavior:

when `PYTHON_ECDSA_ENABLE_LAZY_PRECOMPUTE` env var is set, the multiplication tables for curves are only precomputed upon first use.

without the env var being set (the current behavior), tables for _all_ supported curves are precomputed at import time regardless of whether the curves are used in the user app at all. 

effect can be seen in this test:

```
(cpy382_2) oberstet@intel-nuci7:~/scm/3rdparty/python-ecdsa$ python test.py 
python-ecdsa v0.16.0+1.g3388afc
0.4552568449998944
(cpy382_2) oberstet@intel-nuci7:~/scm/3rdparty/python-ecdsa$ PYTHON_ECDSA_ENABLE_LAZY_PRECOMPUTE=1 python test.py 
python-ecdsa v0.16.0+1.g3388afc
0.020854599999438506
(cpy382_2) oberstet@intel-nuci7:~/scm/3rdparty/python-ecdsa$ 
```

using `test.py`:

```python
import timeit

def test1():
    from ecdsa.curves import SECP256k1

print(timeit.timeit(test1, number=1))
```