### PR TITLE
Exclude version specific coverage

### DIFF
--- a/src/ecdsa/_compat.py
+++ b/src/ecdsa/_compat.py
@@ -14,7 +14,7 @@ def str_idx_as_int(string, index):
     return ord(val)
 
 
-if sys.version_info < (3, 0):
+if sys.version_info < (3, 0):  # pragma: no branch
 
     def normalise_bytes(buffer_object):
         """Cast the input into array of bytes."""
@@ -24,7 +24,11 @@ if sys.version_info < (3, 0):
     def hmac_compat(ret):
         return ret
 
-    if sys.version_info < (2, 7) or sys.version_info < (2, 7, 4):
+    if sys.version_info < (2, 7) or sys.version_info < (  # pragma: no branch
+        2,
+        7,
+        4,
+    ):
 
         def remove_whitespace(text):
             """Removes all whitespace from passed in string"""
@@ -38,11 +42,11 @@ if sys.version_info < (3, 0):
 
 
 else:
-    if sys.version_info < (3, 4):
+    if sys.version_info < (3, 4):  # pragma: no branch
         # on python 3.3 hmac.hmac.update() accepts only bytes, on newer
         # versions it does accept memoryview() also
         def hmac_compat(data):
-            if not isinstance(data, bytes):
+            if not isinstance(data, bytes):  # pragma: no branch
                 return bytes(data)
             return data
 

--- a/src/ecdsa/der.py
+++ b/src/ecdsa/der.py
@@ -386,7 +386,7 @@ def remove_bitstring(string, expect_unused=_sentry):
 
 
 def unpem(pem):
-    if isinstance(pem, text_type):
+    if isinstance(pem, text_type):  # pragma: no branch
         pem = pem.encode()
 
     d = b("").join(

--- a/src/ecdsa/test_ecdh.py
+++ b/src/ecdsa/test_ecdh.py
@@ -300,18 +300,15 @@ def test_ecdh_with_openssl(vcurve):
 
     if vcurve.openssl_name not in OPENSSL_SUPPORTED_CURVES:
         pytest.skip("system openssl does not support " + vcurve.openssl_name)
-        return
 
     try:
         hlp = run_openssl("pkeyutl -help")
-        if hlp.find("-derive") == 0:
+        if hlp.find("-derive") == 0:  # pragma: no cover
             pytest.skip("system openssl does not support `pkeyutl -derive`")
-            return
-    except RunOpenSslError:
+    except RunOpenSslError:  # pragma: no cover
         pytest.skip("system openssl does not support `pkeyutl -derive`")
-        return
 
-    if os.path.isdir("t"):
+    if os.path.isdir("t"):  # pragma: no branch
         shutil.rmtree("t")
     os.mkdir("t")
     run_openssl(
@@ -353,7 +350,7 @@ def test_ecdh_with_openssl(vcurve):
         run_openssl(
             "pkeyutl -derive -inkey t/privkey2.pem -peerkey t/pubkey1.pem -out t/secret2"
         )
-    except RunOpenSslError:
+    except RunOpenSslError:  # pragma: no cover
         pytest.skip("system openssl does not support `pkeyutl -derive`")
         return
 
@@ -362,7 +359,7 @@ def test_ecdh_with_openssl(vcurve):
     with open("t/secret1", "rb") as e:
         ssl_secret2 = e.read()
 
-    if len(ssl_secret1) != vk1.curve.baselen:
+    if len(ssl_secret1) != vk1.curve.baselen:  # pragma: no cover
         pytest.skip("system openssl does not support `pkeyutl -derive`")
         return
 

--- a/src/ecdsa/util.py
+++ b/src/ecdsa/util.py
@@ -33,7 +33,7 @@ oid_ecDH = (1, 3, 132, 1, 12)
 
 oid_ecMQV = (1, 3, 132, 1, 13)
 
-if sys.version_info >= (3,):
+if sys.version_info >= (3,):  # pragma: no branch
 
     def entropy_to_bits(ent_256):
         """Convert a bytestring to string of 0's and 1's"""
@@ -47,7 +47,7 @@ else:
         return "".join(bin(ord(x))[2:].zfill(8) for x in ent_256)
 
 
-if sys.version_info < (2, 7):
+if sys.version_info < (2, 7):  # pragma: no branch
     # Can't add a method to a built-in type so we are stuck with this
     def bit_length(x):
         return len(bin(x)) - 2
@@ -99,7 +99,7 @@ class PRNG:
     def __call__(self, numbytes):
         a = [next(self.generator) for i in range(numbytes)]
 
-        if PY2:
+        if PY2:  # pragma: no branch
             return "".join(a)
         else:
             return bytes(a)

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,10 @@ basepython=python3.9
 [testenv:coverage]
 sitepackages=True
 whitelist_externals=coverage
-commands = coverage run --branch -m pytest --hypothesis-show-statistics {posargs:src/ecdsa}
+commands =
+         coverage run --branch -m pytest --hypothesis-show-statistics {posargs:src/ecdsa}
+         coverage xml
+         coverage report -m
 
 [testenv:speed]
 commands = {envpython} speed.py


### PR DESCRIPTION
coveralls complains about branches that are executed in one environment only, but if they are version specific, that's expected
so try excluding them